### PR TITLE
Add message enums

### DIFF
--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,0 +1,33 @@
+use std::sync::mpsc;
+
+struct Actor {}
+struct Task {}
+type Pos = (usize, usize);
+
+type WorldManagerMailbox =  mpsc::Receiver<(WorldManagerMessage, Actor)>;
+type PlayerManagerMailbox =  mpsc::Receiver<(PlayerManagerMessage, Actor)>;
+type TaskManagerMailbox =  mpsc::Receiver<(TaskManagerMessage, Actor)>;
+type Entity =  mpsc::Receiver<(EntityMessage, Actor)>;
+
+
+
+enum WorldManagerMessage {
+    Move(Pos),
+    TileInfo(Pos),
+    KillMe,
+    GetDisplay,
+}
+
+enum EntityMessage {
+    Task(Task),
+    KillYourself,
+    Ok,
+    Err
+}
+
+enum PlayerManagerMessage {
+}
+
+enum TaskManagerMessage {
+
+}

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -7,7 +7,7 @@ type Pos = (usize, usize);
 type WorldManagerMailbox =  mpsc::Receiver<(WorldManagerMessage, Actor)>;
 type PlayerManagerMailbox =  mpsc::Receiver<(PlayerManagerMessage, Actor)>;
 type TaskManagerMailbox =  mpsc::Receiver<(TaskManagerMessage, Actor)>;
-type Entity =  mpsc::Receiver<(EntityMessage, Actor)>;
+type EntityMailbox =  mpsc::Receiver<(EntityMessage, Actor)>;
 
 
 


### PR DESCRIPTION
Contains definitions for initial message types for communication between modules, and type definitions for mailboxes. This defines what messages can be sent to each module.