### PR TITLE
Actor identifier struct

### DIFF
--- a/src/aid.rs
+++ b/src/aid.rs
@@ -1,9 +1,13 @@
-use std::{sync::mpsc, thread};
+use std::{
+    hash::{Hash, Hasher},
+    sync::mpsc,
+    thread,
+};
 
 // actor identifier
 #[derive(Clone)]
 pub struct AID<T> {
-    pub tid: thread::ThreadId,
+    tid: thread::ThreadId,
     channel: mpsc::Sender<T>,
 }
 
@@ -26,13 +30,28 @@ impl<T> AID<T> {
                 f(aid, reciever)
             }
         });
-        AID {
+        return AID {
             tid: handle.thread().id(),
             channel: sender,
-        }
+        };
     }
 
     pub fn send(&self, t: T) -> Result<(), mpsc::SendError<T>> {
-        self.channel.send(t)
+        return self.channel.send(t);
+    }
+}
+
+// two AIDs are equal iff their TIDs are equal
+impl<T> PartialEq for AID<T> {
+    fn eq(&self, aid: &AID<T>) -> bool {
+        return self.tid == aid.tid;
+    }
+}
+impl<T> Eq for AID<T> {}
+
+// hash AID to same value as its TID
+impl<T> Hash for AID<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.tid.hash(state);
     }
 }

--- a/src/aid.rs
+++ b/src/aid.rs
@@ -1,0 +1,38 @@
+use std::{sync::mpsc, thread};
+
+// actor identifier
+#[derive(Clone)]
+pub struct AID<T> {
+    pub tid: thread::ThreadId,
+    channel: mpsc::Sender<T>,
+}
+
+impl<T> AID<T> {
+    // creates a channel and spawns a thread running f
+    pub fn new<F>(f: F) -> Self
+    where
+        F: FnOnce(AID<T>, mpsc::Receiver<T>),
+        F: Send + 'static,
+        T: Send + 'static,
+    {
+        let (sender, reciever) = mpsc::channel();
+        let handle = thread::spawn({
+            let sender = sender.clone();
+            || {
+                let aid = AID {
+                    tid: thread::current().id(),
+                    channel: sender,
+                };
+                f(aid, reciever)
+            }
+        });
+        AID {
+            tid: handle.thread().id(),
+            channel: sender,
+        }
+    }
+
+    pub fn send(&self, t: T) -> Result<(), mpsc::SendError<T>> {
+        self.channel.send(t)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+mod aid;
+
 fn main() {
     println!("Hello, world!");
 }


### PR DESCRIPTION
resolves #14 

Created a struct AID to be thought of as an Erlang PID that contains the thread id and channel sender.

To create an AID you must provide a function that will run in a new thread. The function is passed its own AID and the receiver to its channel and should not return anything.

Currently, the join handle is dropped which means it won't be possible to wait for the thread to finish. I don't think this will be an issue since we can communicate this via channels but it can also be changed later if necessary.
