### PR TITLE
Inventory

### DIFF
--- a/src/aid.rs
+++ b/src/aid.rs
@@ -30,6 +30,7 @@ impl<T> AID<T> {
                 f(aid, reciever)
             }
         });
+        
         return AID {
             tid: handle.thread().id(),
             channel: sender,

--- a/src/aid.rs
+++ b/src/aid.rs
@@ -30,7 +30,6 @@ impl<T> AID<T> {
                 f(aid, reciever)
             }
         });
-        
         return AID {
             tid: handle.thread().id(),
             channel: sender,

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -1,23 +1,38 @@
-use std::sync::mpsc::{Receiver};
+use std::{
+    sync::Mutex,
+    sync::Arc,
+};
 
 struct Inventory {
-    items: usize, // I'm thinking a list or a hashmap or something, array would also work since the inventory size should probably be fixed
+    items: Arc<Mutex<(String, usize)>>, // Resources are stored as (String, usize) where String is name of resource and usize is count
 }
 
 pub mod inventory {
-    use std::sync::mpsc;
-    use crate::aid::{self, AID};
+    use std::{
+        sync::{Arc, Mutex}, thread::{self, JoinHandle}
+    };
 
-    use crate::inventory::Inventory;
+    use crate::{inventory::Inventory};
 
-    pub fn init<T>(AID: AID<T>, receiver: mpsc::Receiver<T>) { // Not completely sure how the invariant is supposed to be used.
-        let inventory: Inventory = Inventory { items: 0 };
-        main_loop(inventory);
+    pub fn init(name: String) -> (JoinHandle<()>, Arc<Mutex<(String, usize)>>) {
+        let inv_mut: Arc<Mutex<(String, usize)>> = Arc::new(Mutex::new((String::from("Mutexium"), 0)));
+        let inventory: Inventory = Inventory { items: inv_mut.clone() };
+
+        let handle: thread::JoinHandle<()> = thread::spawn(|| main_loop(inventory, name));
+
+        return (handle, inv_mut);
     }
 
-    fn main_loop(inventory: Inventory) {
+    fn main_loop(inventory: Inventory, name: String) {
         loop {
+            // TODO: Do something here, this is just a placeholder
+            println!("In {}...", name);
 
+            let mut contents = inventory.items.lock().unwrap();
+
+            (*contents).1 += 1;
+
+            println!("{0} - {1}", (*contents).0, (*contents).1);
         }
     }
 }

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -1,16 +1,36 @@
-use std::{collections::HashMap};
+use std::{collections::HashMap, hash::Hash};
 
 use crate::{
     aid::AID, 
 };
 
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub enum Item {
     Mutexium,
 }
 
+impl PartialEq for Item {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Item::Mutexium, Item::Mutexium) => return true
+        }
+    }
+}
+
+impl Eq for Item { }
+
+impl Hash for Item {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            Item::Mutexium => {
+                state.write_u8(1);
+            }
+        }
+    }
+}
+
 impl Item {
-    fn to_string(&self) -> &str {
+    fn to_str(&self) -> &str {
         match self {
             Item::Mutexium => return "Mutexium",
         };
@@ -20,17 +40,17 @@ impl Item {
 #[derive(Clone)]
 pub enum InventoryMessage {
     // The following are sent by owner (entity)
-    Add((Item, usize)),
-    Remove((Item, usize)),
+    Give((Item, usize)),
+    Take((Item, usize)),
     TakeFrom(AID<InventoryMessage>, (Item, usize)), 
     GiveTo(AID<InventoryMessage>, (Item, usize)),
     Kill,
 
     // The following are sent by another inventory
-    GiveMeItem(AID<InventoryMessage>),                       // From TakeFrom 
-    GiveMeItemResult(Result<(Item, usize), &'static str>), // From GiveMeItem
-    TakeMyItem(AID<InventoryMessage>, (Item, usize)),        // From GiveTo
-    TakeMyItemResult(Result<(Item, usize), &'static str>),   // From TakeMyItem
+    GiveMeItems(AID<InventoryMessage>, (Item, usize)),      // From TakeFrom 
+    GiveMeItemResult(Result<(Item, usize), &'static str>),  // From GiveMeItem
+    TakeMyItems(AID<InventoryMessage>, (Item, usize)),      // From GiveTo
+    TakeMyItemsResult(Result<(Item, usize), &'static str>), // From TakeMyItem
 }
 
 
@@ -38,30 +58,48 @@ struct Inventory {
     aid: AID<InventoryMessage>,
     max: usize,
     waiting: Vec<AID<InventoryMessage>>,
-    // items: (String, usize), // Resources are stored as (String, usize) where String is name of resource and usize is count
     items: HashMap<Item, (usize, usize)>, // Key: Name of item -> Value: (count, max).
 }
 
 impl Inventory {
     fn construct(aid: AID<InventoryMessage>) -> Self {
-        // return Inventory { aid, max: 10, waiting: Vec::new(), items: (String::from("Mutexium"), 0) };
-        return Inventory { aid, max: 10, waiting: Vec::new(), items: HashMap::new() };
+        let mut inventory = Inventory { aid, max: 10, waiting: Vec::new(), items: HashMap::new() };
+        inventory.items.insert(Item::Mutexium, (0, 0));
+        return inventory;
+    }
+    
+    fn give(&mut self, (item, count): (Item, usize)) {
+        // if is_full() or whatever return false
+
+        self.items.entry(item).or_insert((count, 0)).0 += count;
+
+        return  /* true */;
     }
 
-    fn is_empty(&self) -> bool {
-        return self.items.1 == 0; // FIX
+    fn take(&mut self, (item, count): (Item, usize)) -> bool {
+        if self.too_few_items((item, count)) {
+            return false;
+        }
+
+        let value = self.items.get_mut(&item).unwrap();
+        value.0 -= count;
+        return true;
     }
 
-    fn is_full(&self) -> bool {
-        return self.items.1 == self.max; // FIX
+    fn too_few_items(&self, (item, count): (Item, usize)) -> bool {
+        return self.items.get(&item).unwrap().0 < count;
     }
+
+    // fn is_full(&self) -> bool {
+    //     return self.items.1 == self.max; // FIX: not needed for minimal viable product
+    // }
 
     // For debugging as of now
     fn print_inv(&self, name: String) {
         println!("{0}:\n", name);
         
         for (key, value) in &self.items {
-            println!("      {0} - {1}/{2}\n", key.to_string(), value.0, value.1);
+            println!("      {0} - {1}/{2}\n", key.to_str(), value.0, value.1);
         }
     }
 }
@@ -71,7 +109,7 @@ pub mod inventory {
         aid::AID, 
         inventory::{
             Inventory, 
-            InventoryMessage, 
+            InventoryMessage,
             Item
         }
     };
@@ -91,57 +129,52 @@ pub mod inventory {
 
         loop {
             match mailbox.recv().unwrap() {
-                InventoryMessage::Add(item) => add(&mut inventory, item),
-                InventoryMessage::Remove(item) => remove(&mut inventory, item),
+                InventoryMessage::Give(item) => give(&mut inventory, item),
+                InventoryMessage::Take(item) => take(&mut inventory, item),
                 InventoryMessage::TakeFrom(other, items) => 
                     take_from(&inventory, other, items, &mut transfer_in_process),
                 InventoryMessage::GiveTo(other, items) => 
                     give_to(&inventory, other, items, &mut transfer_in_process),
                 InventoryMessage::Kill => return, 
 
-                InventoryMessage::GiveMeItem(sender) => 
-                    give_me_item(&mut inventory, sender, &mut transfer_in_process),
+                InventoryMessage::GiveMeItems(sender, item) => 
+                    give_me_items(&mut inventory, sender, item, &mut transfer_in_process),
                 InventoryMessage::GiveMeItemResult(result) => {
-                    give_me_item_result(&mut inventory, result);
+                    give_me_items_result(&mut inventory, result);
                     transfer_in_process = false;
                 }
-                InventoryMessage::TakeMyItem(sender, item) => 
-                    take_my_item(&inventory, sender, item, &mut transfer_in_process),
-                InventoryMessage::TakeMyItemResult(result) => 
-                    take_my_item_result(&mut inventory, result),
+                InventoryMessage::TakeMyItems(sender, item) => 
+                    take_my_items(&inventory, sender, item, &mut transfer_in_process),
+                InventoryMessage::TakeMyItemsResult(result) => 
+                    take_my_items_result(&mut inventory, result),
             };
 
             inventory.print_inv(String::from("Inventory"));
         }
     }
 
-    /// Increase this inventory by one, will not do anything if inventory is full.
+    /// Gives some count of Item to inventory.
     /// 
     /// # Arguments
     /// 
     /// * 'inventory' - Mutable reference to the inventory to increase
-    fn add(inventory: &mut Inventory, item: (Item, usize)) {
-        if inventory.is_full() {
-            return; // Error or something
-        }
-
-        inventory.items.1 += 1;
+    /// * 'item'      - Tuple of Item and amount to take
+    fn give(inventory: &mut Inventory, item: (Item, usize)) {
+        // FIXME: INVENTORIES ARE INFINITE FOR FIRST DEMO
+        inventory.give(item);
 
         return; // Success or something
     }
 
-    /// Decrease this inventory by one, will not do anything if inventory is empty.
+    /// Takes some count of Items from inventory, will not do anything if inventory is empty.
     /// 
     /// # Arguments
     /// 
-    /// * 'inventory' - Mutable reference to the inventory to decrease
-    fn remove(inventory: &mut Inventory, item: (Item, usize)) {
-        if inventory.is_empty() {
-            return; // Error or something
-        }
-
-        inventory.items.1 -= 1;
-
+    /// * 'inventory' - Mutable reference to the inventory to take from
+    /// * 'item'      - Tuple of Item and amount to take
+    fn take(inventory: &mut Inventory, item: (Item, usize)) {
+        inventory.take(item);
+        
         return; // Success or something
     }
 
@@ -152,25 +185,26 @@ pub mod inventory {
     /// 
     /// * 'inventory'            - Reference to the inventory to move item to 
     /// * 'aid'                  - AID of the inventory to take from
+    /// * 'items'                - Tuple of Item and amount to take
     /// * 'transfer_in_progress' - Bool that is true if there is already a transfer in progress, else false
     fn take_from(
         inventory: &Inventory, 
         aid: AID<InventoryMessage>, 
-        items: (Item, usize),
+        item: (Item, usize),
         transfer_in_progress: &mut bool
     ) {
-        if *transfer_in_progress || inventory.is_full() {
+        if *transfer_in_progress /*|| inventory.is_full() */ {
             return; // Should send an error or whatever
         }
 
         *transfer_in_progress = true;
-        _ = aid.send(InventoryMessage::GiveMeItem(inventory.aid.clone())); // Should handle Result in some way
+        _ = aid.send(InventoryMessage::GiveMeItems(inventory.aid.clone(), item)); // Should handle Result in some way
     }
 
     fn give_to(
         inventory: &Inventory, 
         aid: AID<InventoryMessage>, 
-        items: (Item, usize),
+        item: (Item, usize),
         transfer_in_progress: &mut bool
     ) {
 
@@ -183,10 +217,12 @@ pub mod inventory {
     /// 
     /// * 'inventory'            - Mutable reference to this inventory
     /// * 'sender'               - AID of the requesting inventory
+    /// * 'items'                - Tuple of Item and amount to take
     /// * 'transfer_in_progress' - Bool that is true if there is already a transfer in progress, else false
-    fn give_me_item(
+    fn give_me_items(
         inventory: &mut Inventory, 
         sender: AID<InventoryMessage>, 
+        item: (Item, usize),
         transfer_in_progress: &mut bool
     ) {
         if *transfer_in_progress {
@@ -194,14 +230,14 @@ pub mod inventory {
             return;
         }
 
-        if inventory.is_empty() {
+        if inventory.too_few_items(item) {
             _ = sender.send(InventoryMessage::GiveMeItemResult(Result::Err("I'm empty!"))); // Sends an error; TODO: Should handle Result in some way
             return;
         }
 
 
-        inventory.items.1 -= 1;
-        _ = sender.send(InventoryMessage::GiveMeItemResult(Result::Ok((inventory.items.0.clone(), 1)))); // Sends a tuple containing what item it is and how many it moved; TODO: Should handle Result in some way
+        inventory.take(item);
+        _ = sender.send(InventoryMessage::GiveMeItemResult(Result::Ok(item))); // Sends a tuple containing what item it is and how many it moved; TODO: Should handle Result in some way
     }
 
     /// Gets the result from a GiveMeItem message and add the item to this inventory, or prints the
@@ -212,14 +248,14 @@ pub mod inventory {
     /// * 'inventory' - Mutable reference to this inventory
     /// * 'result'    - A result containing either a tuple of what item was moved and the quantity, 
     ///                 or the error message as a str
-    fn give_me_item_result(inventory: &mut Inventory, result: Result<(Item, usize), &'static str>) {
+    fn give_me_items_result(inventory: &mut Inventory, result: Result<(Item, usize), &'static str>) {
         match result {
-            Ok(item) => { inventory.items.1 += item.1; }, // This is a placeholder
-            Err(msg) => { println!("{}", msg) } // should probably do something else
+            Ok(item) => { inventory.give(item) },
+            Err(msg) => { println!("{}", msg) }    // should probably do something else
         };
     }
 
-    fn take_my_item(
+    fn take_my_items(
         inventory: &Inventory, 
         sender: AID<InventoryMessage>, 
         items: (Item, usize), 
@@ -228,7 +264,7 @@ pub mod inventory {
 
     }
 
-    fn take_my_item_result(
+    fn take_my_items_result(
         inventory: &mut Inventory, 
         result: Result<(Item, usize), &'static str>
     ) {

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -7,9 +7,9 @@ use crate::{
     aid::AID, 
 };
 
-struct Inventory { // Think about moving the Arc to be the entire inventory
+pub struct Inventory {
     max: usize,
-    items: Arc<Mutex<(String, usize)>>, // Resources are stored as (String, usize) where String is name of resource and usize is count
+    items: (String, usize), // Resources are stored as (String, usize) where String is name of resource and usize is count
 }
 
 pub enum InventoryMessage {
@@ -20,7 +20,7 @@ pub enum InventoryMessage {
     Kill,
 
     // The following are sent by another inventory
-    MoveTo(Inventory),  
+    MoveTo(Arc<Mutex<Inventory>>),  
 }
 
 pub mod inventory {
@@ -33,80 +33,111 @@ pub mod inventory {
         inventory::{Inventory, InventoryMessage}
     };
 
+
+    /// Initializes a new inventory and returns its AID
     pub fn init() -> AID<InventoryMessage> {
-        return AID::new(main_loop);
+        return AID::new(inventory_loop);
     }
 
-    fn construct_inventory() -> Inventory {
-        let inv_arc: Arc<Mutex<(String, usize)>> = Arc::new(
-                                                Mutex::new((String::from("Mutexium"), 0))
-                                                    );
-        return Inventory { max: 10, items: inv_arc };
+    /// Constructs the inventory
+    /// 
+    /// NOTE: Could be moved to be a method of inventory if that is desired
+    fn construct_inventory() -> Arc<Mutex<Inventory>> {
+        return Arc::new(Mutex::new(Inventory { 
+                                            max: 10,
+                                            items: (String::from("Mutexium"), 0),
+                                        }));
     }
 
-    fn main_loop(_aid: AID<InventoryMessage>, mailbox: std::sync::mpsc::Receiver<InventoryMessage>) {
-        let inventory: Inventory = construct_inventory();
+    fn inventory_loop(
+            _aid: AID<InventoryMessage>, 
+            mailbox: std::sync::mpsc::Receiver<InventoryMessage>
+        ){
+        let inventory: Arc<Mutex<Inventory>> = construct_inventory();
 
         loop {
-            for msg in &mailbox {
-                match msg {
-                    InventoryMessage::Increase => increase(&inventory),
-                    InventoryMessage::Decrease => decrease(&inventory),
-                    InventoryMessage::TakeFrom(other) => take_from(&inventory, other),
-                    InventoryMessage::Kill => return,
+            match mailbox.recv().unwrap() { // Recv blocks the thread until a message is recieved which seems right for this
+                InventoryMessage::Increase => increase(inventory.clone()),
+                InventoryMessage::Decrease => decrease(inventory.clone()),
+                InventoryMessage::TakeFrom(other) => 
+                    take_from(inventory.clone(), other),
+                InventoryMessage::Kill => return,
 
-                    InventoryMessage::MoveTo(other_inventory) => move_to(&inventory, &other_inventory), // This is a placeholder
-                };
-            }
+                InventoryMessage::MoveTo(other_inventory) => 
+                    move_to(inventory.clone(), other_inventory),
+            };
         }
     }
 
-    // Increase this inventory by one, will not do anything if inventory is full.
-    fn increase(inventory: &Inventory) {
-        if is_full(inventory) {
+    /// Increase this inventory by one, will not do anything if inventory is full.
+    /// 
+    /// # Arguments
+    /// 
+    /// * 'inventory' - Atomic Reference Counter to the inventory to increase
+    fn increase(inventory: Arc<Mutex<Inventory>>) {
+        if is_full(inventory.clone()) {
             return; // Error or something
         }
 
-        let mut contents: MutexGuard<'_, (String, usize)> = inventory.items.lock().unwrap(); 
-        (*contents).1 += 1;
+        let mut contents: MutexGuard<'_, Inventory> = inventory.lock().unwrap(); 
+        (*contents).items.1 += 1;
 
         return; // Success or something
     }
 
-    // Decrease this inventory by one, will not do anything if inventory is empty.
-    fn decrease(inventory: &Inventory) {
-        if is_empty(inventory) {
+    /// Decrease this inventory by one, will not do anything if inventory is empty.
+    /// 
+    /// # Arguments
+    /// 
+    /// * 'inventory' - Atomic Reference Counter to the inventory to increase
+    fn decrease(inventory: Arc<Mutex<Inventory>>) {
+        if is_empty(inventory.clone()) {
             return; // Error or something
         }
 
-        let mut contents: MutexGuard<'_, (String, usize)> = inventory.items.lock().unwrap(); 
-        (*contents).1 -= 1;
+        let mut contents: MutexGuard<'_, Inventory> = inventory.lock().unwrap(); 
+        (*contents).items.1 -= 1;
 
         return; // Success or something
     }
 
-    // Moves an item from 'from to 'to'. 
-    fn move_to(from: &Inventory, to: &Inventory) {
-        if is_empty(from) || is_full(to) {
+    /// Moves an item from 'from to 'to'. 
+    /// 
+    /// # Arguments
+    /// 
+    /// * 'from' - Atomic Reference Counter to inventory to move the item from
+    /// * 'to' - Atomic Reference Counter to inventory to move item to
+    fn move_to(from: Arc<Mutex<Inventory>>, to: Arc<Mutex<Inventory>>) {
+        if is_empty(from.clone()) || is_full(to.clone()) {
             return; // ERROR or something
         }
 
-        decrease(from);
-        increase(to);
+        decrease(from.clone());
+        increase(to.clone());
 
         return; // Success or something
     }
 
-    fn take_from(inventory: &Inventory, aid: AID<InventoryMessage>) {
-        aid.send(InventoryMessage::MoveTo(inventory));
+    /// Asks the other inventory to perform the move_to function with 
+    /// this inventory as 'to' parameter
+    /// 
+    /// # Arguments
+    /// 
+    /// * 'inventory' - Atomic Reference Counter to calling inventory 
+    /// * 'aid' - AID of the inventory to take from
+    fn take_from(inventory: Arc<Mutex<Inventory>>, aid: AID<InventoryMessage>) {
+        _ = aid.send(InventoryMessage::MoveTo(inventory)); // Should handle Result in some way
     }
 
-    fn is_empty(inventory: &Inventory) -> bool { // Could be a method of Inventory
-        return (*inventory.items.lock().unwrap()).1 == 0;
+
+    // Non message functions
+    fn is_empty(inventory: Arc<Mutex<Inventory>>) -> bool { // Could be a method of Inventory
+        return (*inventory.lock().unwrap()).items.1 == 0;
     }
 
-    fn is_full(inventory: &Inventory) -> bool { // Could be a method of Inventory
-        return (*inventory.items.lock().unwrap()).1 == inventory.max;
+    fn is_full(inventory: Arc<Mutex<Inventory>>) -> bool { // Could be a method of Inventory
+        let unlocked_inv: &Inventory = &(*inventory.lock().unwrap());
+        return unlocked_inv.items.1 == unlocked_inv.max;
     }
 
     // For debugging as of now

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -9,30 +9,59 @@ struct Inventory {
 
 pub mod inventory {
     use std::{
-        sync::{Arc, Mutex}, thread::{self, JoinHandle}
+        sync::{Arc, Mutex, MutexGuard}, thread::{self, JoinHandle}
     };
 
     use crate::{inventory::Inventory};
 
-    pub fn init(name: String) -> (JoinHandle<()>, Arc<Mutex<(String, usize)>>) {
+    pub fn init() -> (JoinHandle<()>, Arc<Mutex<(String, usize)>>) {
         let inv_mut: Arc<Mutex<(String, usize)>> = Arc::new(Mutex::new((String::from("Mutexium"), 0)));
         let inventory: Inventory = Inventory { items: inv_mut.clone() };
 
-        let handle: thread::JoinHandle<()> = thread::spawn(|| main_loop(inventory, name));
+        let handle: thread::JoinHandle<()> = thread::spawn(|| main_loop(inventory));
 
         return (handle, inv_mut);
     }
 
-    fn main_loop(inventory: Inventory, name: String) {
+    fn main_loop(inventory: Inventory) {
         loop {
-            // TODO: Do something here, this is just a placeholder
-            println!("In {}...", name);
+            // // TODO: Do something here, this is just a placeholder
+            // println!("In {}...", name);
 
-            let mut contents = inventory.items.lock().unwrap();
+            // let mut contents = inventory.items.lock().unwrap();
 
-            (*contents).1 += 1;
+            // (*contents).1 += 1;
 
-            println!("{0} - {1}", (*contents).0, (*contents).1);
+            // println!("{0} - {1}", (*contents).0, (*contents).1);
         }
+    }
+
+    /*
+        These functions should be in the entities (probably) and not public
+        nvm i think this works since this is a module that can just be imported
+     */
+    pub fn increase(/*inventory: Inventory or*/ items: &Arc<Mutex<(String, usize)>>) {
+        let mut contents: MutexGuard<'_, (String, usize)> = items.lock().unwrap(); 
+        (*contents).1 += 1;
+    }
+
+    pub fn decrease(/*inventory: Inventory or*/ items: &Arc<Mutex<(String, usize)>>) {
+        let mut contents: MutexGuard<'_, (String, usize)> = items.lock().unwrap(); 
+        (*contents).1 -= 1;
+    }
+
+    /**
+     * Moves from from to to
+     */
+    pub fn r#move(from: &Arc<Mutex<(String, usize)>>, to: &Arc<Mutex<(String, usize)>>) {
+        decrease(from);
+        increase(to);
+    }
+
+    // For debugging as of now
+    pub fn print_inv(this_items: &Arc<Mutex<(String, usize)>>, name: String) {
+        let contents: MutexGuard<'_, (String, usize)> = this_items.lock().unwrap();
+
+        println!("{0} - {1}", name, (*contents).1);
     }
 }

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -2,7 +2,7 @@ use crate::{
     aid::AID, 
 };
 
-pub struct Inventory {
+struct Inventory {
     aid: AID<InventoryMessage>,
     max: usize,
     items: (String, usize), // Resources are stored as (String, usize) where String is name of resource and usize is count

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -208,9 +208,9 @@ pub mod inventory {
         item: (Item, usize),
         transfer_in_progress: &mut bool
     ) {
-        if *transfer_in_progress /*|| inventory.is_full() */ {
-            return; // Should send an error or whatever
-        }
+        // if *transfer_in_progress /*|| inventory.is_full() */ {
+        //     return; // Should send an error or whatever
+        // }
 
         *transfer_in_progress = true;
         _ = aid.send(InventoryMessage::GiveMeItems(inventory.aid.clone(), item)); // Should handle Result in some way
@@ -231,9 +231,9 @@ pub mod inventory {
         item: (Item, usize),
         transfer_in_progress: &mut bool
     ) {
-        if *transfer_in_progress /*|| inventory.is_full() */ {
-            return; // Should send an error or whatever
-        }
+        // if *transfer_in_progress /*|| inventory.is_full() */ {
+        //     return; // Should send an error or whatever
+        // }
 
         *transfer_in_progress = true;
         _ = aid.send(InventoryMessage::TakeMyItems(inventory.aid.clone(), item));
@@ -254,10 +254,10 @@ pub mod inventory {
         item: (Item, usize),
         transfer_in_progress: &mut bool
     ) {
-        if *transfer_in_progress {
-            _ = sender.send(InventoryMessage::GiveMeItemResult(Result::Err("I'm busy!"))); // Sends an error; TODO: Should handle Result in some way
-            return;
-        }
+        // if *transfer_in_progress {
+        //     _ = sender.send(InventoryMessage::GiveMeItemResult(Result::Err("I'm busy!"))); // Sends an error; TODO: Should handle Result in some way
+        //     return;
+        // }
 
         if inventory.has_too_few_items(item) {
             _ = sender.send(InventoryMessage::GiveMeItemResult(Result::Err("I'm empty!"))); // Sends an error; TODO: Should handle Result in some way
@@ -303,9 +303,9 @@ pub mod inventory {
         items: (Item, usize), 
         transfer_in_progress: &mut bool
     ) {
-        if *transfer_in_progress {
-            _ = sender.send(InventoryMessage::TakeMyItemsResult(Result::Err("I'm busy!")));
-        }
+        // if *transfer_in_progress {
+        //     _ = sender.send(InventoryMessage::TakeMyItemsResult(Result::Err("I'm busy!")));
+        // }
 
         if inventory.is_full() { // FIXME: this wont happen as is_full is not implemented
             _ = sender.send(InventoryMessage::TakeMyItemsResult(Result::Err("I'm full!"))); // Sends an error; TODO: Should handle Result in some way

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -40,8 +40,8 @@ impl Item {
 #[derive(Clone)]
 pub enum InventoryMessage {
     // The following are sent by owner (entity)
-    Give((Item, usize)),
-    Take((Item, usize)),
+    Add((Item, usize)),
+    Remove((Item, usize)),
     TakeFrom(AID<InventoryMessage>, (Item, usize)), 
     GiveTo(AID<InventoryMessage>, (Item, usize)),
     Kill,
@@ -77,7 +77,7 @@ impl Inventory {
     }
 
     fn take(&mut self, (item, count): (Item, usize)) -> bool {
-        if self.too_few_items((item, count)) {
+        if self.has_too_few_items((item, count)) {
             return false;
         }
 
@@ -86,7 +86,7 @@ impl Inventory {
         return true;
     }
 
-    fn too_few_items(&self, (item, count): (Item, usize)) -> bool {
+    fn has_too_few_items(&self, (item, count): (Item, usize)) -> bool {
         return self.items.get(&item).unwrap().0 < count;
     }
 
@@ -129,8 +129,8 @@ pub mod inventory {
 
         loop {
             match mailbox.recv().unwrap() {
-                InventoryMessage::Give(item) => give(&mut inventory, item),
-                InventoryMessage::Take(item) => take(&mut inventory, item),
+                InventoryMessage::Add(item) => add(&mut inventory, item),
+                InventoryMessage::Remove(item) => remove(&mut inventory, item),
                 InventoryMessage::TakeFrom(other, items) => 
                     take_from(&inventory, other, items, &mut transfer_in_process),
                 InventoryMessage::GiveTo(other, items) => 
@@ -159,7 +159,7 @@ pub mod inventory {
     /// 
     /// * 'inventory' - Mutable reference to the inventory to increase
     /// * 'item'      - Tuple of Item and amount to take
-    fn give(inventory: &mut Inventory, item: (Item, usize)) {
+    fn add(inventory: &mut Inventory, item: (Item, usize)) {
         // FIXME: INVENTORIES ARE INFINITE FOR FIRST DEMO
         inventory.give(item);
 
@@ -172,7 +172,7 @@ pub mod inventory {
     /// 
     /// * 'inventory' - Mutable reference to the inventory to take from
     /// * 'item'      - Tuple of Item and amount to take
-    fn take(inventory: &mut Inventory, item: (Item, usize)) {
+    fn remove(inventory: &mut Inventory, item: (Item, usize)) {
         inventory.take(item);
         
         return; // Success or something
@@ -230,7 +230,7 @@ pub mod inventory {
             return;
         }
 
-        if inventory.too_few_items(item) {
+        if inventory.has_too_few_items(item) {
             _ = sender.send(InventoryMessage::GiveMeItemResult(Result::Err("I'm empty!"))); // Sends an error; TODO: Should handle Result in some way
             return;
         }

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -1,15 +1,30 @@
-use std::{
-    sync::Mutex,
-    sync::Arc,
-};
-
 use crate::{
     aid::AID, 
 };
 
 pub struct Inventory {
+    aid: AID<InventoryMessage>,
     max: usize,
     items: (String, usize), // Resources are stored as (String, usize) where String is name of resource and usize is count
+}
+
+impl Inventory {
+    fn construct(aid: AID<InventoryMessage>) -> Self {
+        return Inventory { aid, max: 10, items: (String::from("Mutexium"), 0) };
+    }
+
+    fn is_empty(&self) -> bool {
+        return self.items.1 == 0;
+    }
+
+    fn is_full(&self) -> bool {
+        return self.items.1 == self.max;
+    }
+
+    // For debugging as of now
+    fn print_inv(&self, name: String) {
+        println!("{0}: {1} - {2}/{3}", name, self.items.0, self.items.1, self.max);
+    }
 }
 
 #[derive(Clone)]
@@ -21,14 +36,11 @@ pub enum InventoryMessage {
     Kill,
 
     // The following are sent by another inventory
-    MoveTo(Arc<Mutex<Inventory>>),  
+    GiveMeItem(AID<InventoryMessage>),                  // SHOULD ONLY BE CALLED USING TakeFrom MESSAGE
+    ReceiveItem(Result<(String, usize), &'static str>), // SHOULD ONLY BE CALLED USING GiveMeItem MESSAGE
 }
 
 pub mod inventory {
-    use std::{
-        sync::{Arc, Mutex, MutexGuard}
-    };
-
     use crate::{
         aid::AID, 
         inventory::{Inventory, InventoryMessage}
@@ -40,35 +52,30 @@ pub mod inventory {
         return AID::new(inventory_loop);
     }
 
-    /// Constructs the inventory
-    /// 
-    /// NOTE: Could be moved to be a method of inventory if that is desired
-    fn construct_inventory() -> Arc<Mutex<Inventory>> {
-        return Arc::new(Mutex::new(Inventory { 
-                                            max: 10,
-                                            items: (String::from("Mutexium"), 0),
-                                        }));
-    }
-
     fn inventory_loop(
-            _aid: AID<InventoryMessage>, 
+            aid: AID<InventoryMessage>, 
             mailbox: std::sync::mpsc::Receiver<InventoryMessage>
         ){
-        let inventory: Arc<Mutex<Inventory>> = construct_inventory();
+        let mut inventory: Inventory = Inventory::construct(aid);
+        let mut transfer_in_process: bool = false; 
 
         loop {
             match mailbox.recv().unwrap() { // Recv blocks the thread until a message is recieved which seems right for this
-                InventoryMessage::Increase => increase(inventory.clone()),
-                InventoryMessage::Decrease => decrease(inventory.clone()),
+                InventoryMessage::Increase => increase(&mut inventory),
+                InventoryMessage::Decrease => decrease(&mut inventory),
                 InventoryMessage::TakeFrom(other) => 
-                    take_from(inventory.clone(), other),
-                InventoryMessage::Kill => return,
+                    take_from(&inventory, other, &mut transfer_in_process),
+                InventoryMessage::Kill => return, 
 
-                InventoryMessage::MoveTo(other_inventory) => 
-                    move_to(inventory.clone(), other_inventory),
+                InventoryMessage::GiveMeItem(sender) => 
+                    give_me_item(&mut inventory, sender, &mut transfer_in_process),
+                InventoryMessage::ReceiveItem(result) => {
+                    receive_item(&mut inventory, result);
+                    transfer_in_process = false;
+                }
             };
 
-            print_inv(&inventory, String::from("Inventory"));
+            inventory.print_inv(String::from("Inventory"));
         }
     }
 
@@ -76,14 +83,13 @@ pub mod inventory {
     /// 
     /// # Arguments
     /// 
-    /// * 'inventory' - Atomic Reference Counter to the inventory to increase
-    fn increase(inventory: Arc<Mutex<Inventory>>) {
-        if is_full(inventory.clone()) {
+    /// * 'inventory' - Mutable reference to the inventory to increase
+    fn increase(inventory: &mut Inventory) {
+        if inventory.is_full() {
             return; // Error or something
         }
 
-        let mut contents: MutexGuard<'_, Inventory> = inventory.lock().unwrap(); 
-        (*contents).items.1 += 1;
+        inventory.items.1 += 1;
 
         return; // Success or something
     }
@@ -92,61 +98,78 @@ pub mod inventory {
     /// 
     /// # Arguments
     /// 
-    /// * 'inventory' - Atomic Reference Counter to the inventory to increase
-    fn decrease(inventory: Arc<Mutex<Inventory>>) {
-        if is_empty(inventory.clone()) {
+    /// * 'inventory' - Mutable reference to the inventory to decrease
+    fn decrease(inventory: &mut Inventory) {
+        if inventory.is_empty() {
             return; // Error or something
         }
 
-        let mut contents: MutexGuard<'_, Inventory> = inventory.lock().unwrap(); 
-        (*contents).items.1 -= 1;
+        inventory.items.1 -= 1;
 
         return; // Success or something
     }
 
-    /// Moves an item from 'from to 'to'. 
+    /// Asks the other inventory to perform the give_me_item function with 
+    /// this inventorys AID as 'sender' parameter
     /// 
     /// # Arguments
     /// 
-    /// * 'from' - Atomic Reference Counter to inventory to move the item from
-    /// * 'to' - Atomic Reference Counter to inventory to move item to
-    fn move_to(from: Arc<Mutex<Inventory>>, to: Arc<Mutex<Inventory>>) {
-        if is_empty(from.clone()) || is_full(to.clone()) {
-            return; // ERROR or something
+    /// * 'inventory'            - Reference to the inventory to move item to 
+    /// * 'aid'                  - AID of the inventory to take from
+    /// * 'transfer_in_progress' - Bool that is true if there is already a transfer in progress, else false
+    fn take_from(
+        inventory: &Inventory, 
+        aid: AID<InventoryMessage>, 
+        transfer_in_progress: &mut bool
+    ) {
+        if *transfer_in_progress || inventory.is_full() {
+            return; // Should send an error or whatever
         }
 
-        decrease(from.clone());
-        increase(to.clone());
-
-        return; // Success or something
+        *transfer_in_progress = true;
+        _ = aid.send(InventoryMessage::GiveMeItem(inventory.aid.clone())); // Should handle Result in some way
     }
 
-    /// Asks the other inventory to perform the move_to function with 
-    /// this inventory as 'to' parameter
+    /// Checks if this inventory can give item and sends a result containing either a tuple containing
+    /// what item and quantity, or an error containing a string explaining what went wrong.
     /// 
     /// # Arguments
     /// 
-    /// * 'inventory' - Atomic Reference Counter to calling inventory 
-    /// * 'aid' - AID of the inventory to take from
-    fn take_from(inventory: Arc<Mutex<Inventory>>, aid: AID<InventoryMessage>) {
-        _ = aid.send(InventoryMessage::MoveTo(inventory)); // Should handle Result in some way
+    /// * 'inventory'            - Mutable reference to this inventory
+    /// * 'sender'               - AID of the requesting inventory
+    /// * 'transfer_in_progress' - Bool that is true if there is already a transfer in progress, else false
+    fn give_me_item(
+        inventory: &mut Inventory, 
+        sender: AID<InventoryMessage>, 
+        transfer_in_progress: &mut bool
+    ) {
+        if *transfer_in_progress {
+            _ = sender.send(InventoryMessage::ReceiveItem(Result::Err("I'm busy!"))); // Sends an error; TODO: Should handle Result in some way
+            return;
+        }
+
+        if inventory.is_empty() {
+            _ = sender.send(InventoryMessage::ReceiveItem(Result::Err("I'm empty!"))); // Sends an error; TODO: Should handle Result in some way
+            return;
+        }
+
+
+        inventory.items.1 -= 1;
+        _ = sender.send(InventoryMessage::ReceiveItem(Result::Ok((inventory.items.0.clone(), 1)))); // Sends a tuple containing what item it is and how many it moved; TODO: Should handle Result in some way
     }
 
-
-    // Non message functions
-    fn is_empty(inventory: Arc<Mutex<Inventory>>) -> bool { // Could be a method of Inventory
-        return (*inventory.lock().unwrap()).items.1 == 0;
-    }
-
-    fn is_full(inventory: Arc<Mutex<Inventory>>) -> bool { // Could be a method of Inventory
-        let unlocked_inv: &Inventory = &(*inventory.lock().unwrap());
-        return unlocked_inv.items.1 == unlocked_inv.max;
-    }
-
-    // For debugging as of now
-    fn print_inv(this_items: &Arc<Mutex<Inventory>>, name: String) {
-        let contents: MutexGuard<'_, Inventory> = this_items.lock().unwrap();
-
-        println!("{0}: {1} - {2}/{3}", name, (*contents).items.0, (*contents).items.1, (*contents).max);
+    /// Gets the result from a GiveMeItem message and add the item to this inventory, or prints the
+    /// error message if GiveMeItem failed.
+    /// 
+    /// # Arguments
+    /// 
+    /// * 'inventory' - Mutable reference to this inventory
+    /// * 'result'    - A result containing either a tuple of what item was moved and the quantity, 
+    ///                 or the error message as a str
+    fn receive_item(inventory: &mut Inventory, result: Result<(String, usize), &'static str>) {
+        match result {
+            Ok(item) => { inventory.items.1 += item.1; }, // This is a placeholder
+            Err(msg) => { println!("{}", msg) } // should probably do something else
+        };
     }
 }

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -12,6 +12,7 @@ pub struct Inventory {
     items: (String, usize), // Resources are stored as (String, usize) where String is name of resource and usize is count
 }
 
+#[derive(Clone)]
 pub enum InventoryMessage {
     // The following are sent by owner (entity)
     Increase,
@@ -66,6 +67,8 @@ pub mod inventory {
                 InventoryMessage::MoveTo(other_inventory) => 
                     move_to(inventory.clone(), other_inventory),
             };
+
+            print_inv(&inventory, String::from("Inventory"));
         }
     }
 
@@ -141,9 +144,9 @@ pub mod inventory {
     }
 
     // For debugging as of now
-    fn print_inv(this_items: &Arc<Mutex<(String, usize)>>, name: String) {
-        let contents: MutexGuard<'_, (String, usize)> = this_items.lock().unwrap();
+    fn print_inv(this_items: &Arc<Mutex<Inventory>>, name: String) {
+        let contents: MutexGuard<'_, Inventory> = this_items.lock().unwrap();
 
-        println!("{0} - {1}", name, (*contents).1);
+        println!("{0}: {1} - {2}/{3}", name, (*contents).items.0, (*contents).items.1, (*contents).max);
     }
 }

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -1,52 +1,13 @@
-use std::{collections::HashMap, hash::Hash};
+use std::{collections::HashMap};
 
 use crate::{
     aid::AID, 
+    item::Item
 };
-
-#[derive(Clone, Copy)]
-pub enum Item {
-    Mutexium,
-    Semaphorite,
-}
-
-impl PartialEq for Item {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Item::Mutexium, Item::Mutexium) => return true,
-            (Item::Semaphorite, Item::Semaphorite) => return true,
-            _ => return false,
-        };
-    }
-}
-
-impl Eq for Item { }
-
-impl Hash for Item {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        match self {
-            Item::Mutexium => {
-                state.write_u8(1);
-            }
-            Item::Semaphorite => {
-                state.write_u8(1);
-            }
-        }
-    }
-}
-
-impl Item {
-    fn to_str(&self) -> &str {
-        match self {
-            Item::Mutexium => return "Mutexium",
-            Item::Semaphorite => return "Semaphorite",
-        };
-    }
-}
 
 #[derive(Clone)]
 pub enum InventoryMessage {
-    // The following are sent by owner (entity)
+    // The following are sent by owner (entity) (public)
     Add((Item, usize)),
     Remove((Item, usize)),
     TakeFrom(AID<InventoryMessage>, (Item, usize)), 
@@ -54,7 +15,7 @@ pub enum InventoryMessage {
     PrintInventory(String),
     Kill,
 
-    // The following are sent by another inventory
+    // The following are sent by another inventory (private)
     GiveMeItems(AID<InventoryMessage>, (Item, usize)),      // From TakeFrom 
     GiveMeItemResult(Result<(Item, usize), &'static str>),  // From GiveMeItems
     TakeMyItems(AID<InventoryMessage>, (Item, usize)),      // From GiveTo
@@ -79,7 +40,6 @@ impl Inventory {
         };
 
         inventory.items.insert(Item::Mutexium, (0, 0));
-        inventory.items.insert(Item::Semaphorite, (0, 0));
         
         return inventory;
     }
@@ -87,7 +47,7 @@ impl Inventory {
     fn give(&mut self, (item, count): (Item, usize)) {
         // if is_full() or whatever return false
 
-        self.items.entry(item).or_insert((count, 0)).0 += count;
+        self.items.entry(item).or_insert((0, 0)).0 += count;
 
         return  /* true */;
     }
@@ -141,27 +101,27 @@ pub mod inventory {
             mailbox: std::sync::mpsc::Receiver<InventoryMessage>
         ){
         let mut inventory: Inventory = Inventory::construct(aid);
-        let mut transfer_in_process: bool = false; 
+        // let mut transfer_in_process: bool = false; 
 
         loop {
             match mailbox.recv().unwrap() {
                 InventoryMessage::Add(item) => add(&mut inventory, item),
                 InventoryMessage::Remove(item) => remove(&mut inventory, item),
                 InventoryMessage::TakeFrom(other, items) => 
-                    take_from(&inventory, other, items, &mut transfer_in_process),
+                    take_from(&inventory, other, items, /*&mut transfer_in_process*/),
                 InventoryMessage::GiveTo(other, items) => 
-                    give_to(&inventory, other, items, &mut transfer_in_process),
+                    give_to(&inventory, other, items, /*&mut transfer_in_process*/),
                 InventoryMessage::PrintInventory(name   ) => inventory.print_inv(name),
                 InventoryMessage::Kill => return, 
 
                 InventoryMessage::GiveMeItems(sender, item) => 
-                    give_me_items(&mut inventory, sender, item, &mut transfer_in_process),
+                    give_me_items(&mut inventory, sender, item, /*&mut transfer_in_process*/),
                 InventoryMessage::GiveMeItemResult(result) => {
                     give_me_items_result(&mut inventory, result);
-                    transfer_in_process = false;
+                    // transfer_in_process = false;
                 }
                 InventoryMessage::TakeMyItems(sender, item) => 
-                    take_my_items(&mut inventory, sender, item, &mut transfer_in_process),
+                    take_my_items(&mut inventory, sender, item, /*&mut transfer_in_process*/),
                 InventoryMessage::TakeMyItemsResult(result) => 
                     take_my_items_result(&mut inventory, result),
             };            
@@ -206,13 +166,13 @@ pub mod inventory {
         inventory: &Inventory, 
         aid: AID<InventoryMessage>, 
         item: (Item, usize),
-        transfer_in_progress: &mut bool
+        // transfer_in_progress: &mut bool
     ) {
         // if *transfer_in_progress /*|| inventory.is_full() */ {
         //     return; // Should send an error or whatever
         // }
 
-        *transfer_in_progress = true;
+        // *transfer_in_progress = true;
         _ = aid.send(InventoryMessage::GiveMeItems(inventory.aid.clone(), item)); // Should handle Result in some way
     }
 
@@ -229,13 +189,13 @@ pub mod inventory {
         inventory: &Inventory, 
         aid: AID<InventoryMessage>, 
         item: (Item, usize),
-        transfer_in_progress: &mut bool
+        // transfer_in_progress: &mut bool
     ) {
         // if *transfer_in_progress /*|| inventory.is_full() */ {
         //     return; // Should send an error or whatever
         // }
 
-        *transfer_in_progress = true;
+        // *transfer_in_progress = true;
         _ = aid.send(InventoryMessage::TakeMyItems(inventory.aid.clone(), item));
     }
 
@@ -252,7 +212,7 @@ pub mod inventory {
         inventory: &mut Inventory, 
         sender: AID<InventoryMessage>, 
         item: (Item, usize),
-        transfer_in_progress: &mut bool
+        // transfer_in_progress: &mut bool
     ) {
         // if *transfer_in_progress {
         //     _ = sender.send(InventoryMessage::GiveMeItemResult(Result::Err("I'm busy!"))); // Sends an error; TODO: Should handle Result in some way
@@ -301,7 +261,7 @@ pub mod inventory {
         inventory: &mut Inventory, 
         sender: AID<InventoryMessage>, 
         items: (Item, usize), 
-        transfer_in_progress: &mut bool
+        // transfer_in_progress: &mut bool
     ) {
         // if *transfer_in_progress {
         //     _ = sender.send(InventoryMessage::TakeMyItemsResult(Result::Err("I'm busy!")));

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -1,0 +1,23 @@
+use std::sync::mpsc::{Receiver};
+
+struct Inventory {
+    items: usize,
+}
+
+pub mod inventory {
+    use std::sync::mpsc;
+    use crate::aid::{self, AID};
+
+    use crate::inventory::Inventory;
+
+    pub fn init<T>(AID: AID<T>, receiver: mpsc::Receiver<T>) {
+        let inventory: Inventory = Inventory { items: 0 };
+        main_loop(inventory);
+    }
+
+    fn main_loop(inventory: Inventory) {
+        loop {
+
+        }
+    }
+}

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -1,49 +1,79 @@
+use std::{collections::HashMap};
+
 use crate::{
     aid::AID, 
 };
 
-struct Inventory {
-    aid: AID<InventoryMessage>,
-    max: usize,
-    items: (String, usize), // Resources are stored as (String, usize) where String is name of resource and usize is count
+#[derive(Clone)]
+pub enum Item {
+    Mutexium,
 }
 
-impl Inventory {
-    fn construct(aid: AID<InventoryMessage>) -> Self {
-        return Inventory { aid, max: 10, items: (String::from("Mutexium"), 0) };
-    }
-
-    fn is_empty(&self) -> bool {
-        return self.items.1 == 0;
-    }
-
-    fn is_full(&self) -> bool {
-        return self.items.1 == self.max;
-    }
-
-    // For debugging as of now
-    fn print_inv(&self, name: String) {
-        println!("{0}: {1} - {2}/{3}", name, self.items.0, self.items.1, self.max);
+impl Item {
+    fn to_string(&self) -> &str {
+        match self {
+            Item::Mutexium => return "Mutexium",
+        };
     }
 }
 
 #[derive(Clone)]
 pub enum InventoryMessage {
     // The following are sent by owner (entity)
-    Increase,
-    Decrease,
-    TakeFrom(AID<InventoryMessage>), 
+    Add((Item, usize)),
+    Remove((Item, usize)),
+    TakeFrom(AID<InventoryMessage>, (Item, usize)), 
+    GiveTo(AID<InventoryMessage>, (Item, usize)),
     Kill,
 
     // The following are sent by another inventory
-    GiveMeItem(AID<InventoryMessage>),                  // SHOULD ONLY BE CALLED USING TakeFrom MESSAGE
-    ReceiveItem(Result<(String, usize), &'static str>), // SHOULD ONLY BE CALLED USING GiveMeItem MESSAGE
+    GiveMeItem(AID<InventoryMessage>),                       // From TakeFrom 
+    GiveMeItemResult(Result<(Item, usize), &'static str>), // From GiveMeItem
+    TakeMyItem(AID<InventoryMessage>, (Item, usize)),        // From GiveTo
+    TakeMyItemResult(Result<(Item, usize), &'static str>),   // From TakeMyItem
+}
+
+
+struct Inventory {
+    aid: AID<InventoryMessage>,
+    max: usize,
+    waiting: Vec<AID<InventoryMessage>>,
+    // items: (String, usize), // Resources are stored as (String, usize) where String is name of resource and usize is count
+    items: HashMap<Item, (usize, usize)>, // Key: Name of item -> Value: (count, max).
+}
+
+impl Inventory {
+    fn construct(aid: AID<InventoryMessage>) -> Self {
+        // return Inventory { aid, max: 10, waiting: Vec::new(), items: (String::from("Mutexium"), 0) };
+        return Inventory { aid, max: 10, waiting: Vec::new(), items: HashMap::new() };
+    }
+
+    fn is_empty(&self) -> bool {
+        return self.items.1 == 0; // FIX
+    }
+
+    fn is_full(&self) -> bool {
+        return self.items.1 == self.max; // FIX
+    }
+
+    // For debugging as of now
+    fn print_inv(&self, name: String) {
+        println!("{0}:\n", name);
+        
+        for (key, value) in &self.items {
+            println!("      {0} - {1}/{2}\n", key.to_string(), value.0, value.1);
+        }
+    }
 }
 
 pub mod inventory {
     use crate::{
         aid::AID, 
-        inventory::{Inventory, InventoryMessage}
+        inventory::{
+            Inventory, 
+            InventoryMessage, 
+            Item
+        }
     };
 
 
@@ -60,19 +90,25 @@ pub mod inventory {
         let mut transfer_in_process: bool = false; 
 
         loop {
-            match mailbox.recv().unwrap() { // Recv blocks the thread until a message is recieved which seems right for this
-                InventoryMessage::Increase => increase(&mut inventory),
-                InventoryMessage::Decrease => decrease(&mut inventory),
-                InventoryMessage::TakeFrom(other) => 
-                    take_from(&inventory, other, &mut transfer_in_process),
+            match mailbox.recv().unwrap() {
+                InventoryMessage::Add(item) => add(&mut inventory, item),
+                InventoryMessage::Remove(item) => remove(&mut inventory, item),
+                InventoryMessage::TakeFrom(other, items) => 
+                    take_from(&inventory, other, items, &mut transfer_in_process),
+                InventoryMessage::GiveTo(other, items) => 
+                    give_to(&inventory, other, items, &mut transfer_in_process),
                 InventoryMessage::Kill => return, 
 
                 InventoryMessage::GiveMeItem(sender) => 
                     give_me_item(&mut inventory, sender, &mut transfer_in_process),
-                InventoryMessage::ReceiveItem(result) => {
-                    receive_item(&mut inventory, result);
+                InventoryMessage::GiveMeItemResult(result) => {
+                    give_me_item_result(&mut inventory, result);
                     transfer_in_process = false;
                 }
+                InventoryMessage::TakeMyItem(sender, item) => 
+                    take_my_item(&inventory, sender, item, &mut transfer_in_process),
+                InventoryMessage::TakeMyItemResult(result) => 
+                    take_my_item_result(&mut inventory, result),
             };
 
             inventory.print_inv(String::from("Inventory"));
@@ -84,7 +120,7 @@ pub mod inventory {
     /// # Arguments
     /// 
     /// * 'inventory' - Mutable reference to the inventory to increase
-    fn increase(inventory: &mut Inventory) {
+    fn add(inventory: &mut Inventory, item: (Item, usize)) {
         if inventory.is_full() {
             return; // Error or something
         }
@@ -99,7 +135,7 @@ pub mod inventory {
     /// # Arguments
     /// 
     /// * 'inventory' - Mutable reference to the inventory to decrease
-    fn decrease(inventory: &mut Inventory) {
+    fn remove(inventory: &mut Inventory, item: (Item, usize)) {
         if inventory.is_empty() {
             return; // Error or something
         }
@@ -120,6 +156,7 @@ pub mod inventory {
     fn take_from(
         inventory: &Inventory, 
         aid: AID<InventoryMessage>, 
+        items: (Item, usize),
         transfer_in_progress: &mut bool
     ) {
         if *transfer_in_progress || inventory.is_full() {
@@ -128,6 +165,15 @@ pub mod inventory {
 
         *transfer_in_progress = true;
         _ = aid.send(InventoryMessage::GiveMeItem(inventory.aid.clone())); // Should handle Result in some way
+    }
+
+    fn give_to(
+        inventory: &Inventory, 
+        aid: AID<InventoryMessage>, 
+        items: (Item, usize),
+        transfer_in_progress: &mut bool
+    ) {
+
     }
 
     /// Checks if this inventory can give item and sends a result containing either a tuple containing
@@ -144,18 +190,18 @@ pub mod inventory {
         transfer_in_progress: &mut bool
     ) {
         if *transfer_in_progress {
-            _ = sender.send(InventoryMessage::ReceiveItem(Result::Err("I'm busy!"))); // Sends an error; TODO: Should handle Result in some way
+            _ = sender.send(InventoryMessage::GiveMeItemResult(Result::Err("I'm busy!"))); // Sends an error; TODO: Should handle Result in some way
             return;
         }
 
         if inventory.is_empty() {
-            _ = sender.send(InventoryMessage::ReceiveItem(Result::Err("I'm empty!"))); // Sends an error; TODO: Should handle Result in some way
+            _ = sender.send(InventoryMessage::GiveMeItemResult(Result::Err("I'm empty!"))); // Sends an error; TODO: Should handle Result in some way
             return;
         }
 
 
         inventory.items.1 -= 1;
-        _ = sender.send(InventoryMessage::ReceiveItem(Result::Ok((inventory.items.0.clone(), 1)))); // Sends a tuple containing what item it is and how many it moved; TODO: Should handle Result in some way
+        _ = sender.send(InventoryMessage::GiveMeItemResult(Result::Ok((inventory.items.0.clone(), 1)))); // Sends a tuple containing what item it is and how many it moved; TODO: Should handle Result in some way
     }
 
     /// Gets the result from a GiveMeItem message and add the item to this inventory, or prints the
@@ -166,10 +212,26 @@ pub mod inventory {
     /// * 'inventory' - Mutable reference to this inventory
     /// * 'result'    - A result containing either a tuple of what item was moved and the quantity, 
     ///                 or the error message as a str
-    fn receive_item(inventory: &mut Inventory, result: Result<(String, usize), &'static str>) {
+    fn give_me_item_result(inventory: &mut Inventory, result: Result<(Item, usize), &'static str>) {
         match result {
             Ok(item) => { inventory.items.1 += item.1; }, // This is a placeholder
             Err(msg) => { println!("{}", msg) } // should probably do something else
         };
+    }
+
+    fn take_my_item(
+        inventory: &Inventory, 
+        sender: AID<InventoryMessage>, 
+        items: (Item, usize), 
+        transfer_in_progress: &mut bool
+    ) {
+
+    }
+
+    fn take_my_item_result(
+        inventory: &mut Inventory, 
+        result: Result<(Item, usize), &'static str>
+    ) {
+
     }
 }

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -3,63 +3,114 @@ use std::{
     sync::Arc,
 };
 
-struct Inventory {
+use crate::{
+    aid::AID, 
+};
+
+struct Inventory { // Think about moving the Arc to be the entire inventory
+    max: usize,
     items: Arc<Mutex<(String, usize)>>, // Resources are stored as (String, usize) where String is name of resource and usize is count
+}
+
+pub enum InventoryMessage {
+    // The following are sent by owner (entity)
+    Increase,
+    Decrease,
+    TakeFrom(AID<InventoryMessage>), 
+    Kill,
+
+    // The following are sent by another inventory
+    MoveTo(Inventory),  
 }
 
 pub mod inventory {
     use std::{
-        sync::{Arc, Mutex, MutexGuard}, thread::{self, JoinHandle}
+        sync::{Arc, Mutex, MutexGuard}
     };
 
-    use crate::{inventory::Inventory};
+    use crate::{
+        aid::AID, 
+        inventory::{Inventory, InventoryMessage}
+    };
 
-    pub fn init() -> (JoinHandle<()>, Arc<Mutex<(String, usize)>>) {
-        let inv_mut: Arc<Mutex<(String, usize)>> = Arc::new(Mutex::new((String::from("Mutexium"), 0)));
-        let inventory: Inventory = Inventory { items: inv_mut.clone() };
-
-        let handle: thread::JoinHandle<()> = thread::spawn(|| main_loop(inventory));
-
-        return (handle, inv_mut);
+    pub fn init() -> AID<InventoryMessage> {
+        return AID::new(main_loop);
     }
 
-    fn main_loop(inventory: Inventory) {
+    fn construct_inventory() -> Inventory {
+        let inv_arc: Arc<Mutex<(String, usize)>> = Arc::new(
+                                                Mutex::new((String::from("Mutexium"), 0))
+                                                    );
+        return Inventory { max: 10, items: inv_arc };
+    }
+
+    fn main_loop(_aid: AID<InventoryMessage>, mailbox: std::sync::mpsc::Receiver<InventoryMessage>) {
+        let inventory: Inventory = construct_inventory();
+
         loop {
-            // // TODO: Do something here, this is just a placeholder
-            // println!("In {}...", name);
+            for msg in &mailbox {
+                match msg {
+                    InventoryMessage::Increase => increase(&inventory),
+                    InventoryMessage::Decrease => decrease(&inventory),
+                    InventoryMessage::TakeFrom(other) => take_from(&inventory, other),
+                    InventoryMessage::Kill => return,
 
-            // let mut contents = inventory.items.lock().unwrap();
-
-            // (*contents).1 += 1;
-
-            // println!("{0} - {1}", (*contents).0, (*contents).1);
+                    InventoryMessage::MoveTo(other_inventory) => move_to(&inventory, &other_inventory), // This is a placeholder
+                };
+            }
         }
     }
 
-    /*
-        These functions should be in the entities (probably) and not public
-        nvm i think this works since this is a module that can just be imported
-     */
-    pub fn increase(/*inventory: Inventory or*/ items: &Arc<Mutex<(String, usize)>>) {
-        let mut contents: MutexGuard<'_, (String, usize)> = items.lock().unwrap(); 
+    // Increase this inventory by one, will not do anything if inventory is full.
+    fn increase(inventory: &Inventory) {
+        if is_full(inventory) {
+            return; // Error or something
+        }
+
+        let mut contents: MutexGuard<'_, (String, usize)> = inventory.items.lock().unwrap(); 
         (*contents).1 += 1;
+
+        return; // Success or something
     }
 
-    pub fn decrease(/*inventory: Inventory or*/ items: &Arc<Mutex<(String, usize)>>) {
-        let mut contents: MutexGuard<'_, (String, usize)> = items.lock().unwrap(); 
+    // Decrease this inventory by one, will not do anything if inventory is empty.
+    fn decrease(inventory: &Inventory) {
+        if is_empty(inventory) {
+            return; // Error or something
+        }
+
+        let mut contents: MutexGuard<'_, (String, usize)> = inventory.items.lock().unwrap(); 
         (*contents).1 -= 1;
+
+        return; // Success or something
     }
 
-    /**
-     * Moves from from to to
-     */
-    pub fn r#move(from: &Arc<Mutex<(String, usize)>>, to: &Arc<Mutex<(String, usize)>>) {
+    // Moves an item from 'from to 'to'. 
+    fn move_to(from: &Inventory, to: &Inventory) {
+        if is_empty(from) || is_full(to) {
+            return; // ERROR or something
+        }
+
         decrease(from);
         increase(to);
+
+        return; // Success or something
+    }
+
+    fn take_from(inventory: &Inventory, aid: AID<InventoryMessage>) {
+        aid.send(InventoryMessage::MoveTo(inventory));
+    }
+
+    fn is_empty(inventory: &Inventory) -> bool { // Could be a method of Inventory
+        return (*inventory.items.lock().unwrap()).1 == 0;
+    }
+
+    fn is_full(inventory: &Inventory) -> bool { // Could be a method of Inventory
+        return (*inventory.items.lock().unwrap()).1 == inventory.max;
     }
 
     // For debugging as of now
-    pub fn print_inv(this_items: &Arc<Mutex<(String, usize)>>, name: String) {
+    fn print_inv(this_items: &Arc<Mutex<(String, usize)>>, name: String) {
         let contents: MutexGuard<'_, (String, usize)> = this_items.lock().unwrap();
 
         println!("{0} - {1}", name, (*contents).1);

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -1,7 +1,7 @@
 use std::sync::mpsc::{Receiver};
 
 struct Inventory {
-    items: usize,
+    items: usize, // I'm thinking a list or a hashmap or something, array would also work since the inventory size should probably be fixed
 }
 
 pub mod inventory {
@@ -10,7 +10,7 @@ pub mod inventory {
 
     use crate::inventory::Inventory;
 
-    pub fn init<T>(AID: AID<T>, receiver: mpsc::Receiver<T>) {
+    pub fn init<T>(AID: AID<T>, receiver: mpsc::Receiver<T>) { // Not completely sure how the invariant is supposed to be used.
         let inventory: Inventory = Inventory { items: 0 };
         main_loop(inventory);
     }

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -7,13 +7,16 @@ use crate::{
 #[derive(Clone, Copy)]
 pub enum Item {
     Mutexium,
+    Semaphorite,
 }
 
 impl PartialEq for Item {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (Item::Mutexium, Item::Mutexium) => return true
-        }
+            (Item::Mutexium, Item::Mutexium) => return true,
+            (Item::Semaphorite, Item::Semaphorite) => return true,
+            _ => return false,
+        };
     }
 }
 
@@ -25,6 +28,9 @@ impl Hash for Item {
             Item::Mutexium => {
                 state.write_u8(1);
             }
+            Item::Semaphorite => {
+                state.write_u8(1);
+            }
         }
     }
 }
@@ -33,6 +39,7 @@ impl Item {
     fn to_str(&self) -> &str {
         match self {
             Item::Mutexium => return "Mutexium",
+            Item::Semaphorite => return "Semaphorite",
         };
     }
 }
@@ -44,27 +51,36 @@ pub enum InventoryMessage {
     Remove((Item, usize)),
     TakeFrom(AID<InventoryMessage>, (Item, usize)), 
     GiveTo(AID<InventoryMessage>, (Item, usize)),
+    PrintInventory(String),
     Kill,
 
     // The following are sent by another inventory
     GiveMeItems(AID<InventoryMessage>, (Item, usize)),      // From TakeFrom 
-    GiveMeItemResult(Result<(Item, usize), &'static str>),  // From GiveMeItem
+    GiveMeItemResult(Result<(Item, usize), &'static str>),  // From GiveMeItems
     TakeMyItems(AID<InventoryMessage>, (Item, usize)),      // From GiveTo
-    TakeMyItemsResult(Result<(Item, usize), &'static str>), // From TakeMyItem
+    TakeMyItemsResult(Result<(Item, usize), &'static str>), // From TakeMyItems
 }
 
 
 struct Inventory {
     aid: AID<InventoryMessage>,
-    max: usize,
-    waiting: Vec<AID<InventoryMessage>>,
+    max: usize,                           // ???
+    waiting: Vec<AID<InventoryMessage>>,  // TODO: Not needed for minimum viable product
     items: HashMap<Item, (usize, usize)>, // Key: Name of item -> Value: (count, max).
 }
 
 impl Inventory {
     fn construct(aid: AID<InventoryMessage>) -> Self {
-        let mut inventory = Inventory { aid, max: 10, waiting: Vec::new(), items: HashMap::new() };
+        let mut inventory = Inventory { 
+            aid, 
+            max: 10, 
+            waiting: Vec::new(), 
+            items: HashMap::new() 
+        };
+
         inventory.items.insert(Item::Mutexium, (0, 0));
+        inventory.items.insert(Item::Semaphorite, (0, 0));
+        
         return inventory;
     }
     
@@ -90,16 +106,16 @@ impl Inventory {
         return self.items.get(&item).unwrap().0 < count;
     }
 
-    // fn is_full(&self) -> bool {
-    //     return self.items.1 == self.max; // FIX: not needed for minimal viable product
-    // }
+    fn is_full(&self) -> bool {
+        return false; // FIX: not needed for minimal viable product
+    }
 
     // For debugging as of now
     fn print_inv(&self, name: String) {
-        println!("{0}:\n", name);
+        println!("{0}:", name);
         
         for (key, value) in &self.items {
-            println!("      {0} - {1}/{2}\n", key.to_str(), value.0, value.1);
+            println!("      {0} - {1}/{2}", key.to_str(), value.0, value.1);
         }
     }
 }
@@ -135,6 +151,7 @@ pub mod inventory {
                     take_from(&inventory, other, items, &mut transfer_in_process),
                 InventoryMessage::GiveTo(other, items) => 
                     give_to(&inventory, other, items, &mut transfer_in_process),
+                InventoryMessage::PrintInventory(name   ) => inventory.print_inv(name),
                 InventoryMessage::Kill => return, 
 
                 InventoryMessage::GiveMeItems(sender, item) => 
@@ -144,12 +161,10 @@ pub mod inventory {
                     transfer_in_process = false;
                 }
                 InventoryMessage::TakeMyItems(sender, item) => 
-                    take_my_items(&inventory, sender, item, &mut transfer_in_process),
+                    take_my_items(&mut inventory, sender, item, &mut transfer_in_process),
                 InventoryMessage::TakeMyItemsResult(result) => 
                     take_my_items_result(&mut inventory, result),
-            };
-
-            inventory.print_inv(String::from("Inventory"));
+            };            
         }
     }
 
@@ -178,7 +193,7 @@ pub mod inventory {
         return; // Success or something
     }
 
-    /// Asks the other inventory to perform the give_me_item function with 
+    /// Asks the other inventory to perform the give_me_items function with 
     /// this inventorys AID as 'sender' parameter
     /// 
     /// # Arguments
@@ -201,13 +216,27 @@ pub mod inventory {
         _ = aid.send(InventoryMessage::GiveMeItems(inventory.aid.clone(), item)); // Should handle Result in some way
     }
 
+    /// Asks the other inventory to perform the take_my_items function with 
+    /// this inventorys AID as 'sender' parameter
+    /// 
+    /// # Arguments
+    /// 
+    /// * 'inventory'            - Reference to the inventory to move item from 
+    /// * 'aid'                  - AID of the inventory to give to
+    /// * 'items'                - Tuple of Item and amount to give
+    /// * 'transfer_in_progress' - Bool that is true if there is already a transfer in progress, else false
     fn give_to(
         inventory: &Inventory, 
         aid: AID<InventoryMessage>, 
         item: (Item, usize),
         transfer_in_progress: &mut bool
     ) {
+        if *transfer_in_progress /*|| inventory.is_full() */ {
+            return; // Should send an error or whatever
+        }
 
+        *transfer_in_progress = true;
+        _ = aid.send(InventoryMessage::TakeMyItems(inventory.aid.clone(), item));
     }
 
     /// Checks if this inventory can give item and sends a result containing either a tuple containing
@@ -217,7 +246,7 @@ pub mod inventory {
     /// 
     /// * 'inventory'            - Mutable reference to this inventory
     /// * 'sender'               - AID of the requesting inventory
-    /// * 'items'                - Tuple of Item and amount to take
+    /// * 'items'                - Tuple of Item and amount to give
     /// * 'transfer_in_progress' - Bool that is true if there is already a transfer in progress, else false
     fn give_me_items(
         inventory: &mut Inventory, 
@@ -248,26 +277,59 @@ pub mod inventory {
     /// * 'inventory' - Mutable reference to this inventory
     /// * 'result'    - A result containing either a tuple of what item was moved and the quantity, 
     ///                 or the error message as a str
-    fn give_me_items_result(inventory: &mut Inventory, result: Result<(Item, usize), &'static str>) {
+    fn give_me_items_result(
+        inventory: &mut Inventory, 
+        result: Result<(Item, usize), &'static str>
+    ) {
         match result {
             Ok(item) => { inventory.give(item) },
             Err(msg) => { println!("{}", msg) }    // should probably do something else
         };
     }
 
+    /// Checks if this inventory can take the items and sends a result containing either a tuple 
+    /// containing what item and quantity it took, or an error containing a string explaining what 
+    /// went wrong.
+    /// 
+    /// # Arguments
+    /// 
+    /// * 'inventory'            - Mutable reference to this inventory
+    /// * 'sender'               - AID of the requesting inventory
+    /// * 'items'                - Tuple of Item and amount to get
+    /// * 'transfer_in_progress' - Bool that is true if there is already a transfer in progress, else false
     fn take_my_items(
-        inventory: &Inventory, 
+        inventory: &mut Inventory, 
         sender: AID<InventoryMessage>, 
         items: (Item, usize), 
         transfer_in_progress: &mut bool
     ) {
+        if *transfer_in_progress {
+            _ = sender.send(InventoryMessage::TakeMyItemsResult(Result::Err("I'm busy!")));
+        }
 
+        if inventory.is_full() { // FIXME: this wont happen as is_full is not implemented
+            _ = sender.send(InventoryMessage::TakeMyItemsResult(Result::Err("I'm full!"))); // Sends an error; TODO: Should handle Result in some way
+        } 
+
+        inventory.give(items);
+        _ = sender.send(InventoryMessage::TakeMyItemsResult(Result::Ok(items)));
     }
 
+    /// Gets the result from a TakeMyItems message and removes the items from this inventory, or prints the
+    /// error message if TakeMyItems failed.
+    /// 
+    /// # Arguments
+    /// 
+    /// * 'inventory' - Mutable reference to this inventory
+    /// * 'result'    - A result containing either a tuple of what item was moved and the quantity, 
+    ///                 or the error message as a str
     fn take_my_items_result(
         inventory: &mut Inventory, 
         result: Result<(Item, usize), &'static str>
     ) {
-
+        match result {
+            Ok(item) => { _ = inventory.take(item) },
+            Err(msg) => { println!("{}", msg) }    // should probably do something else
+        };
     }
 }

--- a/src/item.rs
+++ b/src/item.rs
@@ -1,0 +1,16 @@
+use std::{hash::Hash};
+
+#[derive(Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Item {
+    Mutexium,
+    Semaphorite,
+}
+
+impl Item {
+    pub fn to_str(&self) -> &str {
+        match self {
+            Item::Mutexium => return "Mutexium",
+            Item::Semaphorite => return "Semaphorite",
+        };
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,17 +8,18 @@ use inventory::{
 
 fn main() {
     println!("Hello, world!");
+    test_inventory();
 }
 
 fn test_inventory() {
     let inventory_aid: aid::AID<InventoryMessage> = inventory::inventory::init();
     let inventory_aid2: aid::AID<InventoryMessage> = inventory::inventory::init();
 
-    _ = inventory_aid.send(InventoryMessage::Add((Item::Mutexium, 9))); // Adds 9 Mutexium to inventory 1
+    _ = inventory_aid.send(InventoryMessage::Give((Item::Mutexium, 9))); // Adds 9 Mutexium to inventory 1
 
     println!("Moving from inventory 1 to 2");
 
-    _ = inventory_aid2.send(InventoryMessage::TakeFrom(inventory_aid.clone(), (Item::Mutexium, 10))); // One more than there are items, inventory 1 will return an error that is printed
+    _ = inventory_aid2.send(InventoryMessage::TakeFrom(inventory_aid.clone(), (Item::Mutexium, 8))); // Take 8 Mutexium from inventory 1
 
-    loop{}
+    loop {};
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
+use crate::aid::AID;
+
 mod inventory;
 mod aid;
 
 fn main() {
     println!("Hello, world!");
-    
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,28 +1,24 @@
-use core::time;
-use std::{thread::sleep};
-
 mod inventory;
 mod aid;
+
+use inventory::{
+    Item,
+    InventoryMessage,
+};
 
 fn main() {
     println!("Hello, world!");
 }
 
 fn test_inventory() {
-    let inventory_aid: aid::AID<inventory::InventoryMessage> = inventory::inventory::init();
-    let inventory_aid2: aid::AID<inventory::InventoryMessage> = inventory::inventory::init();
+    let inventory_aid: aid::AID<InventoryMessage> = inventory::inventory::init();
+    let inventory_aid2: aid::AID<InventoryMessage> = inventory::inventory::init();
 
-    for _ in 0..9 {
-        _ = inventory_aid.send(inventory::InventoryMessage::Increase); // Minskar inventoryt med 1, om det inte redan är tomt
-        sleep(time::Duration::from_millis(500));
-    }
+    _ = inventory_aid.send(InventoryMessage::Add((Item::Mutexium, 9))); // Adds 9 Mutexium to inventory 1
 
     println!("Moving from inventory 1 to 2");
 
-    for _ in 0..10 { // One more than there are items, inventory 1 will return an error that is printed
-        _ = inventory_aid2.send(inventory::InventoryMessage::TakeFrom(inventory_aid.clone()));
-        sleep(time::Duration::from_millis(500));
-    }
+    _ = inventory_aid2.send(InventoryMessage::TakeFrom(inventory_aid.clone(), (Item::Mutexium, 10))); // One more than there are items, inventory 1 will return an error that is printed
 
     loop{}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,9 @@ mod aid;
 mod messages;
 mod world_manager;
 
+use core::time;
+use std::thread::sleep;
+
 use inventory::{
     Item,
     InventoryMessage,
@@ -14,14 +17,42 @@ fn main() {
 }
 
 fn test_inventory() {
-    let inventory_aid: aid::AID<InventoryMessage> = inventory::inventory::init();
-    let inventory_aid2: aid::AID<InventoryMessage> = inventory::inventory::init();
+    let worker_aid: aid::AID<InventoryMessage> = inventory::inventory::init();
+    let factory_aid1: aid::AID<InventoryMessage> = inventory::inventory::init();
+    let factory_aid2: aid::AID<InventoryMessage> = inventory::inventory::init();
 
-    _ = inventory_aid.send(InventoryMessage::Add((Item::Mutexium, 9))); // Adds 9 Mutexium to inventory 1
+    println!("Creating mutexium in factory 1");
+    _ = factory_aid1.send(InventoryMessage::Add((Item::Mutexium, 9))); // Factory 1 produces 9 mutexium
+    // sleep(time::Duration::from_millis(500));
+    
+    // print_system_status(worker_aid.clone(), factory_aid1.clone(), factory_aid2.clone());
 
-    println!("Moving from inventory 1 to 2");
+    println!("Taking 8 mutexium from factory 1 to worker");
+    _ = worker_aid.send(InventoryMessage::TakeFrom(factory_aid1.clone(), (Item::Mutexium, 8))); // Worker takes 8 Mutexium from factory 1
+    // sleep(time::Duration::from_millis(500));
 
-    _ = inventory_aid2.send(InventoryMessage::TakeFrom(inventory_aid.clone(), (Item::Mutexium, 8))); // Take 8 Mutexium from inventory 1
+    // print_system_status(worker_aid.clone(), factory_aid1.clone(), factory_aid2.clone());
+
+    println!("Giving 8 mutexium from worker to factory 2");
+    _ = worker_aid.send(InventoryMessage::GiveTo(factory_aid2.clone(), (Item::Mutexium, 8))); // Worker gives 8 Mutexium to factory 2
+    // sleep(time::Duration::from_millis(500));
+
+    print_system_status(worker_aid.clone(), factory_aid1.clone(), factory_aid2.clone());
 
     loop {};
+}
+
+fn print_system_status(
+    worker_aid: aid::AID<InventoryMessage>, 
+    factory_aid1: aid::AID<InventoryMessage>,
+    factory_aid2: aid::AID<InventoryMessage>,
+) {
+    _ = worker_aid.send(InventoryMessage::PrintInventory(String::from("Worker")));
+    sleep(time::Duration::from_millis(500));
+
+    _ = factory_aid1.send(InventoryMessage::PrintInventory(String::from("Factory 1")));
+    sleep(time::Duration::from_millis(500));
+
+    _ = factory_aid2.send(InventoryMessage::PrintInventory(String::from("Factory 2")));
+    sleep(time::Duration::from_millis(500));
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ fn test_inventory() {
     let inventory_aid: aid::AID<InventoryMessage> = inventory::inventory::init();
     let inventory_aid2: aid::AID<InventoryMessage> = inventory::inventory::init();
 
-    _ = inventory_aid.send(InventoryMessage::Give((Item::Mutexium, 9))); // Adds 9 Mutexium to inventory 1
+    _ = inventory_aid.send(InventoryMessage::Add((Item::Mutexium, 9))); // Adds 9 Mutexium to inventory 1
 
     println!("Moving from inventory 1 to 2");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,17 @@
 mod inventory;
 mod aid;
 mod messages;
+mod item;
 mod world_manager;
 
 use core::time;
 use std::thread::sleep;
 
 use inventory::{
-    Item,
     InventoryMessage,
 };
+
+use item::Item;
 
 fn main() {
     println!("Hello, world!");
@@ -22,13 +24,13 @@ fn test_inventory() {
     let factory_aid2: aid::AID<InventoryMessage> = inventory::inventory::init();
 
     println!("Creating mutexium in factory 1");
-    _ = factory_aid1.send(InventoryMessage::Add((Item::Mutexium, 8))); // Factory 1 produces 8 mutexium
+    _ = factory_aid1.send(InventoryMessage::Add((Item::Semaphorite, 8))); // Factory 1 produces 8 mutexium
     
     println!("Taking 8 mutexium from factory 1 to worker");
-    _ = worker_aid.send(InventoryMessage::TakeFrom(factory_aid1.clone(), (Item::Mutexium, 8))); // Worker takes 8 Mutexium from factory 1
+    _ = worker_aid.send(InventoryMessage::TakeFrom(factory_aid1.clone(), (Item::Semaphorite, 8))); // Worker takes 8 Mutexium from factory 1
 
     println!("Giving 8 mutexium from worker to factory 2");
-    _ = worker_aid.send(InventoryMessage::GiveTo(factory_aid2.clone(), (Item::Mutexium, 8))); // Worker gives 8 Mutexium to factory 2
+    _ = worker_aid.send(InventoryMessage::GiveTo(factory_aid2.clone(), (Item::Semaphorite, 8))); // Worker gives 8 Mutexium to factory 2
 
     print_system_status(worker_aid.clone(), factory_aid1.clone(), factory_aid2.clone());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use core::time;
-use std::{thread::sleep, time::Duration};
+use std::{thread::sleep};
 
 mod inventory;
 mod aid;
@@ -12,14 +12,14 @@ fn test_inventory() {
     let inventory_aid: aid::AID<inventory::InventoryMessage> = inventory::inventory::init();
     let inventory_aid2: aid::AID<inventory::InventoryMessage> = inventory::inventory::init();
 
-    for _ in 0..10 {
+    for _ in 0..9 {
         _ = inventory_aid.send(inventory::InventoryMessage::Increase); // Minskar inventoryt med 1, om det inte redan är tomt
         sleep(time::Duration::from_millis(500));
     }
 
     println!("Moving from inventory 1 to 2");
 
-    for _ in 0..5 {
+    for _ in 0..10 { // One more than there are items, inventory 1 will return an error that is printed
         _ = inventory_aid2.send(inventory::InventoryMessage::TakeFrom(inventory_aid.clone()));
         sleep(time::Duration::from_millis(500));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,46 +1,6 @@
-use crate::aid::AID;
-
 mod inventory;
 mod aid;
 
-use core::time;
-use std::{
-    sync::{Arc, Mutex, MutexGuard}, thread::sleep,
-};
-
 fn main() {
     println!("Hello, world!");
-    test_inventory2();
-}
-
-fn test_inventory() {
-    let mut inventories: Vec<Arc<Mutex<(String, usize)>>> = Vec::new();
-
-    for i in 1..4 {
-        inventories.push(inventory::inventory::init().1); 
-    }
-
-    let mut inv_1: MutexGuard<'_, (String, usize)> = inventories[0].lock().unwrap();
-
-    (*inv_1).1 = 0;
-
-    loop {} // loop forever so the program doesn't terminate and kill the threads
-}
-
-fn test_inventory2() {
-    let inv_a: Arc<Mutex<(String, usize)>> = inventory::inventory::init().1;
-    let inv_b: Arc<Mutex<(String, usize)>> = inventory::inventory::init().1;
-
-    for _i in 0..10 {
-        inventory::inventory::increase(&inv_a);
-    }
-
-    for _i in 0..10 {
-        inventory::inventory::r#move(&inv_a, &inv_b);
-
-        inventory::inventory::print_inv(&inv_a, String::from("Inventory A"));
-        inventory::inventory::print_inv(&inv_b, String::from("Inventory B"));
-
-        sleep(time::Duration::from_millis(500));
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,28 @@
+use core::time;
+use std::{thread::sleep, time::Duration};
+
 mod inventory;
 mod aid;
 
 fn main() {
     println!("Hello, world!");
+}
+
+fn test_inventory() {
+    let inventory_aid: aid::AID<inventory::InventoryMessage> = inventory::inventory::init();
+    let inventory_aid2: aid::AID<inventory::InventoryMessage> = inventory::inventory::init();
+
+    for _ in 0..10 {
+        _ = inventory_aid.send(inventory::InventoryMessage::Increase); // Minskar inventoryt med 1, om det inte redan är tomt
+        sleep(time::Duration::from_millis(500));
+    }
+
+    println!("Moving from inventory 1 to 2");
+
+    for _ in 0..5 {
+        _ = inventory_aid2.send(inventory::InventoryMessage::TakeFrom(inventory_aid.clone()));
+        sleep(time::Duration::from_millis(500));
+    }
+
+    loop{}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,24 +22,15 @@ fn test_inventory() {
     let factory_aid2: aid::AID<InventoryMessage> = inventory::inventory::init();
 
     println!("Creating mutexium in factory 1");
-    _ = factory_aid1.send(InventoryMessage::Add((Item::Mutexium, 9))); // Factory 1 produces 9 mutexium
-    // sleep(time::Duration::from_millis(500));
+    _ = factory_aid1.send(InventoryMessage::Add((Item::Mutexium, 8))); // Factory 1 produces 8 mutexium
     
-    // print_system_status(worker_aid.clone(), factory_aid1.clone(), factory_aid2.clone());
-
     println!("Taking 8 mutexium from factory 1 to worker");
     _ = worker_aid.send(InventoryMessage::TakeFrom(factory_aid1.clone(), (Item::Mutexium, 8))); // Worker takes 8 Mutexium from factory 1
-    // sleep(time::Duration::from_millis(500));
-
-    // print_system_status(worker_aid.clone(), factory_aid1.clone(), factory_aid2.clone());
 
     println!("Giving 8 mutexium from worker to factory 2");
     _ = worker_aid.send(InventoryMessage::GiveTo(factory_aid2.clone(), (Item::Mutexium, 8))); // Worker gives 8 Mutexium to factory 2
-    // sleep(time::Duration::from_millis(500));
 
     print_system_status(worker_aid.clone(), factory_aid1.clone(), factory_aid2.clone());
-
-    loop {};
 }
 
 fn print_system_status(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
+mod inventory;
 mod aid;
 
 fn main() {
     println!("Hello, world!");
+    
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,24 @@ use crate::aid::AID;
 mod inventory;
 mod aid;
 
+use std::{
+    sync::{Arc, Mutex, MutexGuard},
+};
+
 fn main() {
     println!("Hello, world!");
+}
+
+fn test_inventory() {
+    let mut inventories: Vec<Arc<Mutex<(String, usize)>>> = Vec::new();
+
+    for i in 1..4 {
+        inventories.push(inventory::inventory::init(format!("Thread {}", i)).1); 
+    }
+
+    let mut inv_1: MutexGuard<'_, (String, usize)> = inventories[0].lock().unwrap();
+
+    (*inv_1).1 = 0;
+
+    loop {} // loop forever so the program doesn't terminate and kill the threads
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,19 +3,21 @@ use crate::aid::AID;
 mod inventory;
 mod aid;
 
+use core::time;
 use std::{
-    sync::{Arc, Mutex, MutexGuard},
+    sync::{Arc, Mutex, MutexGuard}, thread::sleep,
 };
 
 fn main() {
     println!("Hello, world!");
+    test_inventory2();
 }
 
 fn test_inventory() {
     let mut inventories: Vec<Arc<Mutex<(String, usize)>>> = Vec::new();
 
     for i in 1..4 {
-        inventories.push(inventory::inventory::init(format!("Thread {}", i)).1); 
+        inventories.push(inventory::inventory::init().1); 
     }
 
     let mut inv_1: MutexGuard<'_, (String, usize)> = inventories[0].lock().unwrap();
@@ -23,4 +25,22 @@ fn test_inventory() {
     (*inv_1).1 = 0;
 
     loop {} // loop forever so the program doesn't terminate and kill the threads
+}
+
+fn test_inventory2() {
+    let inv_a: Arc<Mutex<(String, usize)>> = inventory::inventory::init().1;
+    let inv_b: Arc<Mutex<(String, usize)>> = inventory::inventory::init().1;
+
+    for _i in 0..10 {
+        inventory::inventory::increase(&inv_a);
+    }
+
+    for _i in 0..10 {
+        inventory::inventory::r#move(&inv_a, &inv_b);
+
+        inventory::inventory::print_inv(&inv_a, String::from("Inventory A"));
+        inventory::inventory::print_inv(&inv_b, String::from("Inventory B"));
+
+        sleep(time::Duration::from_millis(500));
+    }
 }


### PR DESCRIPTION
Så här är tanken att använda inventories:

Man skapar ett inventory genom att kalla `inventory::init()`. Detta skapar en ny inventory-aktör och returnerar AID för den. Ägaren av threaden (alltså entitien) skickar sedan InventoryMessages till inventoryt som hanterar dem. Alla ändringar och flyttningar av items i inventories ska ske mellan inventories.

```
// I någon exempel-entity
let inventory_aid: AID<InventoryMessage> = inventory::init();
inventory_aid.send(InventoryMessage::Decrease); // Minskar inventoryt med 1, om det inte redan är tomt
```

Vissa InventoryMessages är tänkta att användas endast mellan inventories. De som är implementerad är 'GiveMeItem', som skickas när ägaren skickat en 'TakeFrom' instruktion med AID till ett annat inventory, och 'ReceiveItem', som skickas som svar till ett 'GiveMeItem' meddelande. Dessa meddelanden är alltså till för att synkronisera flyttningar och sånt.

```
fn example(some_other_inventory_aid: AID<InventoryMessage>) {
        let inventory_aid: AID<InventoryMessage> = inventory::init();
        inventory_aid.send(InventoryMessage::TakeFrom(some_other_inventory_aid)); // 'inventory_aid' skickar nu ett GiveMeItem-meddelande till 'some_other_inventory_aid' som flyttar en av sina items till 'inventory_aid'
}
```

PS: Notera även att den här koden är inte testad, så det kommer säker uppstå oändligt många buggar.

Closes #12 