### PR TITLE
Add Entity actor without inventory support

### DIFF
--- a/src/building.rs
+++ b/src/building.rs
@@ -56,6 +56,9 @@ impl Building {
                     }
                     EntityMessage::Err => waiting = false,
                     EntityMessage::Task(task) => continue, //Update task
+
+                    EntityMessage::InventoryOk => {},
+                    EntityMessage::InventoryErr => {},
                 }
             }
             if let Some(recipe) = &active_recipe

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -70,7 +70,7 @@ pub struct Entity {
     world_aid: AID<WorldManagerMessage>,
     task_aid: AID<TaskManagerMessage>,
     // senare task_id: AID<inventoryMesseges>
-    self_aid: AID<EntityMessage>,
+    mailbox: AID<EntityMessage>,
 }
 
 impl Entity {
@@ -84,7 +84,7 @@ impl Entity {
                 core: EntityCore::new(start_pos),
                 world_aid: world,
                 task_aid: task,
-                self_aid: aid.clone(),
+                mailbox: aid.clone(),
             };
 
             entity.run(mailbox);
@@ -98,14 +98,14 @@ impl Entity {
                     
                     if let Some(pos) = self.core.apply_task(task) {
                         
-                        let _ = self.world_aid.send(WorldManagerMessage::Move(pos, self.self_aid.clone()));
+                        let _ = self.world_aid.send(WorldManagerMessage::Move(pos, self.mailbox.clone()));
                     }
                 }
 
                 EntityMessage::KillYourself => {
                     let _ = self
                         .world_aid
-                        .send(WorldManagerMessage::KillMe(self.self_aid.clone()));
+                        .send(WorldManagerMessage::KillMe(self.mailbox.clone()));
                     break;
                 }
 
@@ -171,6 +171,7 @@ mod tests {
         core.apply_task(task);
         core.apply_err();
 
+        
         assert_eq!(core.current_pos, start_pos);
         assert_eq!(core.pending_move,None);
 

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -1,6 +1,7 @@
 use crate::aid::AID;
 use crate::messages::{EntityMessage, Task, TaskManagerMessage};
 use crate::world_manager::{Pos, WorldManagerMessage};
+use crate::inventory::{inventory, InventoryMessage};
 use std::sync::mpsc::Receiver;
 
 
@@ -69,7 +70,7 @@ pub struct Entity {
     core: EntityCore,
     world_aid: AID<WorldManagerMessage>,
     task_aid: AID<TaskManagerMessage>,
-    //inventory: AID<inventoryMesseges>
+    inventory: AID<InventoryMessage>,
     mailbox: AID<EntityMessage>,
 }
 
@@ -84,6 +85,7 @@ impl Entity {
                 core: EntityCore::new(start_pos),
                 world_aid: world,
                 task_aid: task,
+                inventory: inventory::init(),
                 mailbox: aid.clone(),
             };
 

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -2,6 +2,7 @@ use crate::aid::AID;
 use crate::inventory::{InventoryMessage, inventory};
 use crate::messages::{EntityMessage, Task, TaskManagerMessage};
 use crate::world_manager::{Pos, WorldManagerMessage};
+use std::io::BufRead;
 use std::sync::mpsc::Receiver;
 
 /// Ren logik- och state för en entity.
@@ -17,6 +18,7 @@ use std::sync::mpsc::Receiver;
 struct EntityCore {
     current_pos: Pos,
     pending_move: Option<Pos>,
+    is_busy: bool,
 }
 
 impl EntityCore {
@@ -25,6 +27,7 @@ impl EntityCore {
         EntityCore {
             current_pos: start_pos,
             pending_move: None,
+            is_busy: false,
         }
     }
 
@@ -34,14 +37,30 @@ impl EntityCore {
         match task {
             Task::MoveTo(pos) => {
                 self.pending_move = Some(pos);
+                self.is_busy = true;
                 Some(pos)
             }
 
-            Task::AddItem { item, amount } => None,
-            Task::RemoveItem { item, amount } => None,
-            Task::TakeFrom { from, item, amount } => None,
-            Task::GiveTo { to, item, amount } => None,
-            Task::PrintInventory(_) => None,
+            Task::AddItem { item, amount } => {
+                self.is_busy = true;
+                None
+            }
+            Task::RemoveItem { item, amount } => {
+                self.is_busy = true;
+                None
+            }
+            Task::TakeFrom { from, item, amount } => {
+                self.is_busy = true;
+                None
+            }
+            Task::GiveTo { to, item, amount } => {
+                self.is_busy = true;
+                None
+            }
+            Task::PrintInventory(_) => {
+                self.is_busy = true;
+                None
+            }
 
             Task::Idle => None,
         }
@@ -51,6 +70,7 @@ impl EntityCore {
     fn apply_ok(&mut self) {
         if let Some(pos) = self.pending_move.take() {
             self.current_pos = pos;
+            self.is_busy = false;
         }
     }
     /// Anropas när WorldManager nekar en flytt.
@@ -100,8 +120,7 @@ impl Entity {
     fn run(&mut self, mailbox: Receiver<EntityMessage>) {
         for msg in mailbox {
             match msg {
-                EntityMessage::Task(task) => 
-                match task {
+                EntityMessage::Task(task) => match task {
                     Task::MoveTo(pos) => {
                         if let Some(pos) = self.core.apply_task(task) {
                             let _ = self
@@ -150,12 +169,14 @@ impl Entity {
                     //world manager godkände flyyten
                     //uppdatera EntityCore-> cunnrent_pos
                     self.core.apply_ok();
+                    self.core.is_busy = false;
                 }
 
                 EntityMessage::Err => {
                     // world manager neckade flytten
                     // ingen ändring i pos
                     self.core.apply_err();
+                    self.core.is_busy = false;
                 }
             }
         }

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -2,7 +2,6 @@ use crate::aid::AID;
 use crate::inventory::{InventoryMessage, inventory};
 use crate::messages::{EntityMessage, Task, TaskManagerMessage};
 use crate::world_manager::{Pos, WorldManagerMessage};
-use std::io::BufRead;
 use std::sync::mpsc::Receiver;
 
 /// Ren logik- och state för en entity.
@@ -15,12 +14,14 @@ use std::sync::mpsc::Receiver;
 ///
 /// Innehåller ingen actor‑logik.  
 /// Används av `Entity` som den faktiska logikdelen.
+#[allow(dead_code)]
 struct EntityCore {
     current_pos: Pos,
     pending_move: Option<Pos>,
     is_busy: bool,
 }
 
+#[allow(dead_code)]
 impl EntityCore {
     // skapar en EntityCore  med given start position
     fn new(start_pos: Pos) -> EntityCore {
@@ -41,19 +42,19 @@ impl EntityCore {
                 Some(pos)
             }
 
-            Task::AddItem { item, amount } => {
+            Task::AddItem { .. } => {
                 self.is_busy = true;
                 None
             }
-            Task::RemoveItem { item, amount } => {
+            Task::RemoveItem { .. } => {
                 self.is_busy = true;
                 None
             }
-            Task::TakeFrom { from, item, amount } => {
+            Task::TakeFrom { .. } => {
                 self.is_busy = true;
                 None
             }
-            Task::GiveTo { to, item, amount } => {
+            Task::GiveTo { .. } => {
                 self.is_busy = true;
                 None
             }
@@ -105,23 +106,32 @@ impl Entity {
         start_pos: Pos,
     ) -> AID<EntityMessage> {
         AID::new(move |aid, mailbox| {
-            let mut entity = Entity {
-                core: EntityCore::new(start_pos),
-                world_aid: world,
-                task_aid: task,
-                inventory: inventory::init(),
-                mailbox: aid.clone(),
-            };
+            let mut entity = Entity::create(aid.clone(), world, task, start_pos);
 
             entity.run(mailbox);
         })
+    }
+
+    fn create(
+        mailbox: AID<EntityMessage>,
+        world: AID<WorldManagerMessage>,
+        task: AID<TaskManagerMessage>,
+        start_pos: Pos,
+    ) -> Self {
+        Entity {
+            core: EntityCore::new(start_pos),
+            world_aid: world,
+            task_aid: task,
+            inventory: inventory::init(),
+            mailbox: mailbox,
+        }
     }
 
     fn run(&mut self, mailbox: Receiver<EntityMessage>) {
         for msg in mailbox {
             match msg {
                 EntityMessage::Task(task) => match task {
-                    Task::MoveTo(pos) => {
+                    Task::MoveTo(_pos) => {
                         if let Some(pos) = self.core.apply_task(task) {
                             let _ = self
                                 .world_aid
@@ -185,6 +195,10 @@ impl Entity {
 
 #[cfg(test)]
 mod tests {
+    use std::future::poll_fn;
+
+    use crate::messages;
+
     use super::*;
 
     #[test]
@@ -225,5 +239,22 @@ mod tests {
 
         assert_eq!(core.current_pos, start_pos);
         assert_eq!(core.pending_move, None);
+    }
+
+    #[test]
+
+    fn is_bussy(){
+
+        let start_pos = (10,10);
+        let mut core  = EntityCore::new(start_pos);
+          assert_eq!(core.is_busy, false);
+
+        let new_pos = (20,20);
+        let task = messages::Task::MoveTo(new_pos);
+        core.apply_task(task);
+
+        assert_eq!(core.is_busy, true);
+
+
     }
 }

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -14,14 +14,14 @@ use std::sync::mpsc::Receiver;
 ///
 /// Innehåller ingen actor‑logik.  
 /// Används av `Entity` som den faktiska logikdelen.
-pub struct EntityCore {
+struct EntityCore {
     current_pos: Pos,
     pending_move: Option<Pos>,
 }
 
 impl EntityCore {
     // skapar en EntityCore  med given start position
-    pub fn new(start_pos: Pos) -> EntityCore {
+    fn new(start_pos: Pos) -> EntityCore {
         EntityCore {
             current_pos: start_pos,
             pending_move: None,
@@ -30,7 +30,7 @@ impl EntityCore {
 
     /// Behandlar en Task och returnerar eventuell Move-position
     /// som Entity-aktorn ska skicka till WorldManager.
-    pub fn apply_task(&mut self, task: Task)-> Option<Pos> {
+    fn apply_task(&mut self, task: Task)-> Option<Pos> {
         match task {
             Task::MoveTo(pos) => {
                 self.pending_move = Some(pos);
@@ -42,14 +42,14 @@ impl EntityCore {
     }
     /// Anropas när WorldManager godkänner en flytt.
     /// Uppdaterar current_pos och tömmer pending_move.
-    pub fn apply_ok(&mut self) {
+    fn apply_ok(&mut self) {
         if let Some(pos) = self.pending_move.take() {
             self.current_pos = pos;
         }
     }
     /// Anropas när WorldManager nekar en flytt.
     /// Tömmer pending_move utan att ändra current_pos.
-    pub fn apply_err(&mut self) {
+    fn apply_err(&mut self) {
         self.pending_move = None;
     }
 }

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -69,7 +69,7 @@ pub struct Entity {
     core: EntityCore,
     world_aid: AID<WorldManagerMessage>,
     task_aid: AID<TaskManagerMessage>,
-    // senare task_id: AID<inventoryMesseges>
+    //inventory: AID<inventoryMesseges>
     mailbox: AID<EntityMessage>,
 }
 

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -1,12 +1,11 @@
 use crate::aid::AID;
+use crate::inventory::{InventoryMessage, inventory};
 use crate::messages::{EntityMessage, Task, TaskManagerMessage};
 use crate::world_manager::{Pos, WorldManagerMessage};
-use crate::inventory::{inventory, InventoryMessage};
 use std::sync::mpsc::Receiver;
 
-
 /// Ren logik- och state för en entity.
-/// 
+///
 /// EntityCore ansvarar för:
 /// - att hålla nuvarande position (`current_pos`)
 /// - att lagra en väntande flytt (`pending_move`)
@@ -31,14 +30,20 @@ impl EntityCore {
 
     /// Behandlar en Task och returnerar eventuell Move-position
     /// som Entity-aktorn ska skicka till WorldManager.
-    fn apply_task(&mut self, task: Task)-> Option<Pos> {
+    fn apply_task(&mut self, task: Task) -> Option<Pos> {
         match task {
             Task::MoveTo(pos) => {
                 self.pending_move = Some(pos);
                 Some(pos)
             }
 
-            Task::Idle => None
+            Task::AddItem { item, amount } => None,
+            Task::RemoveItem { item, amount } => None,
+            Task::TakeFrom { from, item, amount } => None,
+            Task::GiveTo { to, item, amount } => None,
+            Task::PrintInventory(_) => None,
+
+            Task::Idle => None,
         }
     }
     /// Anropas när WorldManager godkänner en flytt.
@@ -55,9 +60,8 @@ impl EntityCore {
     }
 }
 
-
 /// Actor som representerar en Entity i världen.
-/// 
+///
 /// Entity ansvarar för:
 /// - att ta emot `EntityMessage`
 /// - att vidarebefordra tasks till `EntityCore`
@@ -96,13 +100,44 @@ impl Entity {
     fn run(&mut self, mailbox: Receiver<EntityMessage>) {
         for msg in mailbox {
             match msg {
-                EntityMessage::Task(task) => {
-                    
-                    if let Some(pos) = self.core.apply_task(task) {
-                        
-                        let _ = self.world_aid.send(WorldManagerMessage::Move(pos, self.mailbox.clone()));
+                EntityMessage::Task(task) => 
+                match task {
+                    Task::MoveTo(pos) => {
+                        if let Some(pos) = self.core.apply_task(task) {
+                            let _ = self
+                                .world_aid
+                                .send(WorldManagerMessage::Move(pos, self.mailbox.clone()));
+                        }
                     }
-                }
+
+                    Task::AddItem { item, amount } => {
+                        let _ = self.inventory.send(InventoryMessage::Add((item, amount)));
+                    }
+
+                    Task::RemoveItem { item, amount } => {
+                        let _ = self
+                            .inventory
+                            .send(InventoryMessage::Remove((item, amount)));
+                    }
+
+                    Task::TakeFrom { from, item, amount } => {
+                        let _ = self
+                            .inventory
+                            .send(InventoryMessage::TakeFrom(from, (item, amount)));
+                    }
+
+                    Task::GiveTo { to, item, amount } => {
+                        let _ = self
+                            .inventory
+                            .send(InventoryMessage::GiveTo(to, (item, amount)));
+                    }
+
+                    Task::PrintInventory(name) => {
+                        let _ = self.inventory.send(InventoryMessage::PrintInventory(name));
+                    }
+
+                    Task::Idle => {}
+                },
 
                 EntityMessage::KillYourself => {
                     let _ = self
@@ -131,51 +166,43 @@ impl Entity {
 mod tests {
     use super::*;
 
-
     #[test]
     fn apply_task() {
-        
-        let start_pos = (1,1);
+        let start_pos = (1, 1);
         let mut core = EntityCore::new(start_pos);
 
-        let new_pos = (10,10);
+        let new_pos = (10, 10);
         let task = Task::MoveTo(new_pos);
 
         assert_eq!(core.apply_task(task), Some(new_pos));
         assert_eq!(core.pending_move, Some(new_pos));
-
     }
 
     #[test]
-    fn apply_ok(){
-
-        let start_pos = (1,1);
+    fn apply_ok() {
+        let start_pos = (1, 1);
         let mut core = EntityCore::new(start_pos);
 
-        let new_pos = (20,20);
+        let new_pos = (20, 20);
         let task = Task::MoveTo(new_pos);
         core.apply_task(task);
         core.apply_ok();
         assert_eq!(core.current_pos, new_pos);
-
     }
 
     #[test]
     fn apply_err() {
-        
-        let start_pos = (1,1);
+        let start_pos = (1, 1);
         let mut core = EntityCore::new(start_pos);
 
-        let new_pos = (3,8);
+        let new_pos = (3, 8);
 
         let task = Task::MoveTo(new_pos);
 
         core.apply_task(task);
         core.apply_err();
 
-        
         assert_eq!(core.current_pos, start_pos);
-        assert_eq!(core.pending_move,None);
-
+        assert_eq!(core.pending_move, None);
     }
 }

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -1,13 +1,46 @@
 use crate::aid::AID;
-use crate::messages::{EntityMessage, PlayerManagerMessage, Task, TaskManagerMessage};
+use crate::messages::{EntityMessage, Task, TaskManagerMessage};
 use crate::world_manager::{Pos, WorldManagerMessage};
 use std::sync::mpsc::Receiver;
 
-pub struct Entity {
-    world: AID<WorldManagerMessage>,
-    task: AID<TaskManagerMessage>,
+pub struct EntityCore {
     current_pos: Pos,
     pending_move: Option<Pos>,
+}
+
+impl EntityCore {
+    pub fn new(start_pos: Pos) -> EntityCore {
+        EntityCore {
+            current_pos: start_pos,
+            pending_move: None,
+        }
+    }
+
+    pub fn apply_task(&mut self, task: Task)-> Option<Pos> {
+        match task {
+            Task::MoveTo(pos) => {
+                self.pending_move = Some(pos);
+                Some(pos)
+            }
+
+            Task::Idle => None
+        }
+    }
+
+    pub fn apply_ok(&mut self) {
+        if let Some(pos) = self.pending_move.take() {
+            self.current_pos = pos;
+        }
+    }
+
+    pub fn apply_err(&mut self) {
+        self.pending_move = None;
+    }
+}
+pub struct Entity {
+    core: EntityCore,
+    world_aid: AID<WorldManagerMessage>,
+    task_aid: AID<TaskManagerMessage>,
     self_aid: AID<EntityMessage>,
 }
 
@@ -19,10 +52,9 @@ impl Entity {
     ) -> AID<EntityMessage> {
         AID::new(move |aid, mailbox| {
             let mut entity = Entity {
-                world: world,
-                task: task,
-                current_pos: start_pos,
-                pending_move: None,
+                core: EntityCore::new(start_pos),
+                world_aid: world,
+                task_aid: task,
                 self_aid: aid.clone(),
             };
 
@@ -34,45 +66,84 @@ impl Entity {
         for msg in mailbox {
             match msg {
                 EntityMessage::Task(task) => {
-                    self.handle_task(task);
+                    
+                    if let Some(pos) = self.core.apply_task(task) {
+                        
+                        let _ = self.world_aid.send(WorldManagerMessage::Move(pos, self.self_aid.clone()));
+                    }
                 }
 
                 EntityMessage::KillYourself => {
-                    self.world
+                    let _ = self
+                        .world_aid
                         .send(WorldManagerMessage::KillMe(self.self_aid.clone()));
                     break;
                 }
 
                 EntityMessage::Ok => {
                     //world manager godkände flyyten
-                    //uppdatera entitys pos ! exempel self.pos = (1,6);
-                    if let Some(pos) = self.pending_move.take() {
-                        self.current_pos = pos;
-                    }
+                    //uppdatera EntityCore-> cunnrent_pos
+                    self.core.apply_ok();
                 }
 
                 EntityMessage::Err => {
                     // world manager neckade flytten
                     // ingen ändring i pos
-                    self.pending_move = None;
+                    self.core.apply_err();
                 }
             }
         }
     }
+}
 
-    fn handle_task(&mut self, task: Task) {
-        match task {
-            Task::MoveTo(pos) => {
-                self.pending_move = Some(pos);
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-                let _ = self
-                    .world
-                    .send(WorldManagerMessage::Move(pos, self.self_aid.clone()));
-            }
 
-            Task::Idle => {
-                //gör inget
-            }
-        }
+    #[test]
+    fn apply_task() {
+        
+        let start_pos = (1,1);
+        let mut core = EntityCore::new(start_pos);
+
+        let new_pos = (10,10);
+        let task = Task::MoveTo(new_pos);
+
+        assert_eq!(core.apply_task(task), Some(new_pos));
+        assert_eq!(core.pending_move, Some(new_pos));
+
+    }
+
+    #[test]
+    fn apply_ok(){
+
+        let start_pos = (1,1);
+        let mut core = EntityCore::new(start_pos);
+
+        let new_pos = (20,20);
+        let task = Task::MoveTo(new_pos);
+        core.apply_task(task);
+        core.apply_ok();
+        assert_eq!(core.current_pos, new_pos);
+
+    }
+
+    #[test]
+    fn apply_err() {
+        
+        let start_pos = (1,1);
+        let mut core = EntityCore::new(start_pos);
+
+        let new_pos = (3,8);
+
+        let task = Task::MoveTo(new_pos);
+
+        core.apply_task(task);
+        core.apply_err();
+
+        assert_eq!(core.current_pos, start_pos);
+        assert_eq!(core.pending_move,None);
+
     }
 }

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -188,6 +188,20 @@ impl Entity {
                     self.core.apply_err();
                     self.core.is_busy = false;
                 }
+
+                EntityMessage::InventoryOk =>{
+
+                    //tillfälligt lösning
+                    self.core.is_busy = false;
+                }
+
+
+                EntityMessage::InventoryErr =>{
+
+                    //tillfälligt lösning
+                    self.core.is_busy = false;
+
+                }
             }
         }
     }
@@ -195,7 +209,6 @@ impl Entity {
 
 #[cfg(test)]
 mod tests {
-    use std::future::poll_fn;
 
     use crate::messages;
 
@@ -243,18 +256,15 @@ mod tests {
 
     #[test]
 
-    fn is_bussy(){
+    fn is_bussy() {
+        let start_pos = (10, 10);
+        let mut core = EntityCore::new(start_pos);
+        assert_eq!(core.is_busy, false);
 
-        let start_pos = (10,10);
-        let mut core  = EntityCore::new(start_pos);
-          assert_eq!(core.is_busy, false);
-
-        let new_pos = (20,20);
+        let new_pos = (20, 20);
         let task = messages::Task::MoveTo(new_pos);
         core.apply_task(task);
 
         assert_eq!(core.is_busy, true);
-
-
     }
 }

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -1,12 +1,13 @@
 use crate::aid::AID;
-use crate::messages::{EntityMessage, Task, EntityMailbox};
-use crate::world_manager::{WorldManagerMessage, Pos};
-use crate::task_manager::TaskManagerMessage;
+use crate::messages::{EntityMessage, PlayerManagerMessage, Task, TaskManagerMessage};
+use crate::world_manager::{Pos, WorldManagerMessage};
+use std::sync::mpsc::Receiver;
 
 pub struct Entity {
     world: AID<WorldManagerMessage>,
     task: AID<TaskManagerMessage>,
-    pos: Pos,
+    current_pos: Pos,
+    pending_move: Option<Pos>,
     self_aid: AID<EntityMessage>,
 }
 
@@ -18,38 +19,52 @@ impl Entity {
     ) -> AID<EntityMessage> {
         AID::new(move |aid, mailbox| {
             let mut entity = Entity {
-                world,
-                task,
-                pos: start_pos,
+                world: world,
+                task: task,
+                current_pos: start_pos,
+                pending_move: None,
                 self_aid: aid.clone(),
             };
+
             entity.run(mailbox);
         })
     }
 
-    fn run(&mut self, mailbox: EntityMailbox) {
-        for (msg, _sender_actor) in mailbox {
+    fn run(&mut self, mailbox: Receiver<EntityMessage>) {
+        for msg in mailbox {
             match msg {
                 EntityMessage::Task(task) => {
                     self.handle_task(task);
                 }
+
                 EntityMessage::KillYourself => {
-                    let _ = self.world.send(WorldManagerMessage::KillMe(self.self_aid.clone()));
+                    self.world
+                        .send(WorldManagerMessage::KillMe(self.self_aid.clone()));
                     break;
                 }
+
                 EntityMessage::Ok => {
-                    // world manager godkände flytten
-                    // uppdatera position här om du vill
+                    //world manager godkände flyyten
+                    //uppdatera entitys pos ! exempel self.pos = (1,6);
+                    if let Some(pos) = self.pending_move.take() {
+                        self.current_pos = pos;
+                    }
                 }
+
                 EntityMessage::Err => {
-                    // world manager nekade flytten
+                    // world manager neckade flytten
+                    // ingen ändring i pos
+                    self.pending_move = None;
                 }
             }
         }
     }
 
-    fn handle_task(&mut self, _task: Task) {
-        let new_pos = (self.pos.0 + 1, self.pos.1);
-        let _ = self.world.send(WorldManagerMessage::Move(new_pos, self.self_aid.clone()));
+    fn handle_task(&mut self, task: Task) {
+        let new_pos = (self.current_pos.0 + 1, self.current_pos.1 +1);
+        self.pending_move = Some(new_pos);
+        let _ = self
+            .world
+            .send(WorldManagerMessage::Move(new_pos, self.self_aid.clone()));
     }
 }

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -61,10 +61,18 @@ impl Entity {
     }
 
     fn handle_task(&mut self, task: Task) {
-        let new_pos = (self.current_pos.0 + 1, self.current_pos.1 +1);
-        self.pending_move = Some(new_pos);
-        let _ = self
-            .world
-            .send(WorldManagerMessage::Move(new_pos, self.self_aid.clone()));
+        match task {
+            Task::MoveTo(pos) => {
+                self.pending_move = Some(pos);
+
+                let _ = self
+                    .world
+                    .send(WorldManagerMessage::Move(pos, self.self_aid.clone()));
+            }
+
+            Task::Idle => {
+                //gör inget
+            }
+        }
     }
 }

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -1,0 +1,55 @@
+use crate::aid::AID;
+use crate::messages::{EntityMessage, Task, EntityMailbox};
+use crate::world_manager::{WorldManagerMessage, Pos};
+use crate::task_manager::TaskManagerMessage;
+
+pub struct Entity {
+    world: AID<WorldManagerMessage>,
+    task: AID<TaskManagerMessage>,
+    pos: Pos,
+    self_aid: AID<EntityMessage>,
+}
+
+impl Entity {
+    pub fn new(
+        world: AID<WorldManagerMessage>,
+        task: AID<TaskManagerMessage>,
+        start_pos: Pos,
+    ) -> AID<EntityMessage> {
+        AID::new(move |aid, mailbox| {
+            let mut entity = Entity {
+                world,
+                task,
+                pos: start_pos,
+                self_aid: aid.clone(),
+            };
+            entity.run(mailbox);
+        })
+    }
+
+    fn run(&mut self, mailbox: EntityMailbox) {
+        for (msg, _sender_actor) in mailbox {
+            match msg {
+                EntityMessage::Task(task) => {
+                    self.handle_task(task);
+                }
+                EntityMessage::KillYourself => {
+                    let _ = self.world.send(WorldManagerMessage::KillMe(self.self_aid.clone()));
+                    break;
+                }
+                EntityMessage::Ok => {
+                    // world manager godkände flytten
+                    // uppdatera position här om du vill
+                }
+                EntityMessage::Err => {
+                    // world manager nekade flytten
+                }
+            }
+        }
+    }
+
+    fn handle_task(&mut self, _task: Task) {
+        let new_pos = (self.pos.0 + 1, self.pos.1);
+        let _ = self.world.send(WorldManagerMessage::Move(new_pos, self.self_aid.clone()));
+    }
+}

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -3,12 +3,24 @@ use crate::messages::{EntityMessage, Task, TaskManagerMessage};
 use crate::world_manager::{Pos, WorldManagerMessage};
 use std::sync::mpsc::Receiver;
 
+
+/// Ren logik- och state för en entity.
+/// 
+/// EntityCore ansvarar för:
+/// - att hålla nuvarande position (`current_pos`)
+/// - att lagra en väntande flytt (`pending_move`)
+/// - att behandla inkommande tasks
+/// - att uppdatera state baserat på Ok/Err från WorldManager
+///
+/// Innehåller ingen actor‑logik.  
+/// Används av `Entity` som den faktiska logikdelen.
 pub struct EntityCore {
     current_pos: Pos,
     pending_move: Option<Pos>,
 }
 
 impl EntityCore {
+    // skapar en EntityCore  med given start position
     pub fn new(start_pos: Pos) -> EntityCore {
         EntityCore {
             current_pos: start_pos,
@@ -16,6 +28,8 @@ impl EntityCore {
         }
     }
 
+    /// Behandlar en Task och returnerar eventuell Move-position
+    /// som Entity-aktorn ska skicka till WorldManager.
     pub fn apply_task(&mut self, task: Task)-> Option<Pos> {
         match task {
             Task::MoveTo(pos) => {
@@ -26,21 +40,36 @@ impl EntityCore {
             Task::Idle => None
         }
     }
-
+    /// Anropas när WorldManager godkänner en flytt.
+    /// Uppdaterar current_pos och tömmer pending_move.
     pub fn apply_ok(&mut self) {
         if let Some(pos) = self.pending_move.take() {
             self.current_pos = pos;
         }
     }
-
+    /// Anropas när WorldManager nekar en flytt.
+    /// Tömmer pending_move utan att ändra current_pos.
     pub fn apply_err(&mut self) {
         self.pending_move = None;
     }
 }
+
+
+/// Actor som representerar en Entity i världen.
+/// 
+/// Entity ansvarar för:
+/// - att ta emot `EntityMessage`
+/// - att vidarebefordra tasks till `EntityCore`
+/// - att skicka `WorldManagerMessage::Move` när core signalerar en flytt
+/// - att uppdatera core-state baserat på Ok/Err från WorldManager
+///
+/// All logik ligger i `EntityCore`.  
+/// Entity själv hanterar endast actor‑beteende och message‑flow.
 pub struct Entity {
     core: EntityCore,
     world_aid: AID<WorldManagerMessage>,
     task_aid: AID<TaskManagerMessage>,
+    // senare task_id: AID<inventoryMesseges>
     self_aid: AID<EntityMessage>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,8 @@
 mod aid;
+mod entity;
+mod messages;
 
 fn main() {
     println!("Hello, world!");
+    
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,6 @@
 mod aid;
 mod entity;
 mod messages;
-
-mod messages;
 mod world_manager;
 
 fn main() {

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,6 +1,15 @@
 use crate::aid::AID;
+use crate::world_manager::Pos;
 
-pub type Task = ();
+
+#[derive(Clone)]
+pub enum Task{
+    MoveTo(Pos),
+    Idle,
+    // senare:
+    // Gather,
+    // Deliver
+}
 
 #[derive(Clone)]
 pub enum EntityMessage {

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -5,10 +5,20 @@ use crate::world_manager::Pos;
 #[derive(Clone)]
 pub enum Task{
     MoveTo(Pos),
-    Idle,
     // senare:
-    // Gather,
-    // Deliver
+    //TakeFrom{
+        //inventory : AID<InventoryMessage>
+        //item : Item,
+        //amount: usize
+    //},
+    //GiveTo{
+
+        //inventory: AID<InventoryMessage>,
+        //item: Item,
+        //amount: usize
+
+    //},
+    Idle,
 }
 
 #[derive(Clone)]

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -40,6 +40,8 @@ pub enum EntityMessage {
     KillYourself,
     Ok,
     Err,
+    InventoryOk,
+    InventoryErr
 }
 
 #[derive(Clone)]

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,23 +1,36 @@
 use crate::aid::AID;
+use crate::inventory::InventoryMessage;
+use crate::item::Item;
 use crate::world_manager::Pos;
 
-
 #[derive(Clone)]
-pub enum Task{
+pub enum Task {
     MoveTo(Pos),
-    // senare:
-    //TakeFrom{
-        //inventory : AID<InventoryMessage>
-        //item : Item,
-        //amount: usize
-    //},
-    //GiveTo{
 
-        //inventory: AID<InventoryMessage>,
-        //item: Item,
-        //amount: usize
+    AddItem {
+        item: Item,
+        amount: usize,
+    },
 
-    //},
+    RemoveItem {
+        item: Item,
+        amount: usize,
+    },
+
+    TakeFrom {
+        from: AID<InventoryMessage>,
+        item: Item,
+        amount: usize,
+    },
+
+    GiveTo {
+        to: AID<InventoryMessage>,
+        item: Item,
+        amount: usize,
+    },
+
+    PrintInventory(String),
+
     Idle,
 }
 
@@ -35,4 +48,6 @@ pub enum PlayerManagerMessage {
 }
 
 #[derive(Clone)]
-pub enum TaskManagerMessage {}
+pub enum TaskManagerMessage {
+    AssignTask(Task),
+}


### PR DESCRIPTION
Introducerar en Entity-aktör med separerad logik via EntityCore.

- EntityCore hanterar state och logik (current_pos, pending_move samt eventuella framtida attribut)
- Entity ansvarar för actor-beteende och meddelandehantering
- Förflyttning sker via WorldManager (Move + Ok/Err)
- Vid meddelandet KillYourself skickar Entity ett WorldManagerMessage::KillMe och avslutar sin exekvering
- Enhetstester har lagts till för EntityCore

Inventory är ännu inte implementerat (planeras i en framtida PR)

Publikt API:
Det finns en publik funktion för att skapa en Entity (actor):

    Entity::new(world, task, start_pos)

Den tar:
- en AID till WorldManager (för kommunikation)
- en AID till TaskManager
- en startposition (initial position i världen)