### PR TITLE
Basic responses for inventory

### DIFF
--- a/src/building.rs
+++ b/src/building.rs
@@ -56,6 +56,8 @@ impl Building {
                     }
                     EntityMessage::Err => waiting = false,
                     EntityMessage::Task(task) => continue, //Update task
+                    EntityMessage::InventoryOk => /* Something */ continue,
+                    EntityMessage::InventoryErr => /* Something */ continue,
                 }
             }
             if let Some(recipe) = &active_recipe

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -2,24 +2,24 @@ use std::{collections::HashMap};
 
 use crate::{
     aid::AID, 
-    item::Item
+    item::Item, messages::EntityMessage
 };
 
 #[derive(Clone)]
 pub enum InventoryMessage {
     // The following are sent by owner (entity) (public)
-    Add((Item, usize)),
-    Remove((Item, usize)),
-    TakeFrom(AID<InventoryMessage>, (Item, usize)), 
-    GiveTo(AID<InventoryMessage>, (Item, usize)),
+    Add(AID<EntityMessage>, (Item, usize)),
+    Remove(AID<EntityMessage>, (Item, usize)),
+    TakeFrom(AID<EntityMessage>, AID<InventoryMessage>, (Item, usize)), 
+    GiveTo(AID<EntityMessage>, AID<InventoryMessage>, (Item, usize)),
     PrintInventory(String),
     Kill,
 
     // The following are sent by another inventory (private)
-    GiveMeItems(AID<InventoryMessage>, (Item, usize)),      // From TakeFrom 
-    GiveMeItemResult(Result<(Item, usize), &'static str>),  // From GiveMeItems
-    TakeMyItems(AID<InventoryMessage>, (Item, usize)),      // From GiveTo
-    TakeMyItemsResult(Result<(Item, usize), &'static str>), // From TakeMyItems
+    GiveMeItems(AID<EntityMessage>, AID<InventoryMessage>, (Item, usize)),      // From TakeFrom 
+    GiveMeItemResult(AID<EntityMessage>, Result<(Item, usize), &'static str>),  // From GiveMeItems
+    TakeMyItems(AID<EntityMessage>, AID<InventoryMessage>, (Item, usize)),      // From GiveTo
+    TakeMyItemsResult(AID<EntityMessage>, Result<(Item, usize), &'static str>), // From TakeMyItems
 }
 
 
@@ -87,7 +87,7 @@ pub mod inventory {
             Inventory, 
             InventoryMessage,
             Item
-        }
+        }, messages::EntityMessage
     };
 
 
@@ -105,25 +105,37 @@ pub mod inventory {
 
         loop {
             match mailbox.recv().unwrap() {
-                InventoryMessage::Add(item) => add(&mut inventory, item),
-                InventoryMessage::Remove(item) => remove(&mut inventory, item),
-                InventoryMessage::TakeFrom(other, items) => 
-                    take_from(&inventory, other, items, /*&mut transfer_in_process*/),
-                InventoryMessage::GiveTo(other, items) => 
-                    give_to(&inventory, other, items, /*&mut transfer_in_process*/),
-                InventoryMessage::PrintInventory(name   ) => inventory.print_inv(name),
+                InventoryMessage::Add(sender, item) => 
+                    add(sender, &mut inventory, item),
+
+                InventoryMessage::Remove(sender, item) => 
+                    remove(sender, &mut inventory, item),
+
+                InventoryMessage::TakeFrom(sender, other, items) => 
+                    take_from(sender, &inventory, other, items, /*&mut transfer_in_process*/),
+
+                InventoryMessage::GiveTo(sender, other, items) => 
+                    give_to(sender, &inventory, other, items, /*&mut transfer_in_process*/),
+
+                InventoryMessage::PrintInventory(name) => inventory.print_inv(name),
+                
                 InventoryMessage::Kill => return, 
 
-                InventoryMessage::GiveMeItems(sender, item) => 
-                    give_me_items(&mut inventory, sender, item, /*&mut transfer_in_process*/),
-                InventoryMessage::GiveMeItemResult(result) => {
-                    give_me_items_result(&mut inventory, result);
+
+
+                InventoryMessage::GiveMeItems(sender, sending_inventory, item) => 
+                    give_me_items(sender, &mut inventory, sending_inventory, item, /*&mut transfer_in_process*/),
+
+                InventoryMessage::GiveMeItemResult(sender, result) => {
+                    give_me_items_result(sender, &mut inventory, result);
                     // transfer_in_process = false;
                 }
-                InventoryMessage::TakeMyItems(sender, item) => 
-                    take_my_items(&mut inventory, sender, item, /*&mut transfer_in_process*/),
-                InventoryMessage::TakeMyItemsResult(result) => 
-                    take_my_items_result(&mut inventory, result),
+
+                InventoryMessage::TakeMyItems(sender, sending_inventory, item) => 
+                    take_my_items(sender, &mut inventory, sending_inventory, item, /*&mut transfer_in_process*/),
+
+                InventoryMessage::TakeMyItemsResult(sender, result) => 
+                    take_my_items_result(sender, &mut inventory, result),
             };            
         }
     }
@@ -134,11 +146,10 @@ pub mod inventory {
     /// 
     /// * 'inventory' - Mutable reference to the inventory to increase
     /// * 'item'      - Tuple of Item and amount to take
-    fn add(inventory: &mut Inventory, item: (Item, usize)) {
+    fn add(sender: AID<EntityMessage>, inventory: &mut Inventory, item: (Item, usize)) {
         // FIXME: INVENTORIES ARE INFINITE FOR FIRST DEMO
         inventory.give(item);
-
-        return; // Success or something
+        _ = sender.send(EntityMessage::InventoryOk);
     }
 
     /// Takes some count of Items from inventory, will not do anything if inventory is empty.
@@ -147,10 +158,12 @@ pub mod inventory {
     /// 
     /// * 'inventory' - Mutable reference to the inventory to take from
     /// * 'item'      - Tuple of Item and amount to take
-    fn remove(inventory: &mut Inventory, item: (Item, usize)) {
-        inventory.take(item);
-        
-        return; // Success or something
+    fn remove(sender: AID<EntityMessage>, inventory: &mut Inventory, item: (Item, usize)) {
+        if inventory.take(item) {
+            _ = sender.send(EntityMessage::InventoryOk);
+        }
+
+        _ = sender.send(EntityMessage::InventoryErr);
     }
 
     /// Asks the other inventory to perform the give_me_items function with 
@@ -163,6 +176,7 @@ pub mod inventory {
     /// * 'items'                - Tuple of Item and amount to take
     /// * 'transfer_in_progress' - Bool that is true if there is already a transfer in progress, else false
     fn take_from(
+        sender: AID<EntityMessage>,
         inventory: &Inventory, 
         aid: AID<InventoryMessage>, 
         item: (Item, usize),
@@ -173,7 +187,7 @@ pub mod inventory {
         // }
 
         // *transfer_in_progress = true;
-        _ = aid.send(InventoryMessage::GiveMeItems(inventory.aid.clone(), item)); // Should handle Result in some way
+        _ = aid.send(InventoryMessage::GiveMeItems(sender, inventory.aid.clone(), item)); // Should handle Result in some way
     }
 
     /// Asks the other inventory to perform the take_my_items function with 
@@ -186,6 +200,7 @@ pub mod inventory {
     /// * 'items'                - Tuple of Item and amount to give
     /// * 'transfer_in_progress' - Bool that is true if there is already a transfer in progress, else false
     fn give_to(
+        sender: AID<EntityMessage>,
         inventory: &Inventory, 
         aid: AID<InventoryMessage>, 
         item: (Item, usize),
@@ -196,7 +211,7 @@ pub mod inventory {
         // }
 
         // *transfer_in_progress = true;
-        _ = aid.send(InventoryMessage::TakeMyItems(inventory.aid.clone(), item));
+        _ = aid.send(InventoryMessage::TakeMyItems(sender, inventory.aid.clone(), item));
     }
 
     /// Checks if this inventory can give item and sends a result containing either a tuple containing
@@ -209,8 +224,9 @@ pub mod inventory {
     /// * 'items'                - Tuple of Item and amount to give
     /// * 'transfer_in_progress' - Bool that is true if there is already a transfer in progress, else false
     fn give_me_items(
+        sender: AID<EntityMessage>,
         inventory: &mut Inventory, 
-        sender: AID<InventoryMessage>, 
+        sending_inventory: AID<InventoryMessage>, 
         item: (Item, usize),
         // transfer_in_progress: &mut bool
     ) {
@@ -220,13 +236,13 @@ pub mod inventory {
         // }
 
         if inventory.has_too_few_items(item) {
-            _ = sender.send(InventoryMessage::GiveMeItemResult(Result::Err("I'm empty!"))); // Sends an error; TODO: Should handle Result in some way
+            _ = sending_inventory.send(InventoryMessage::GiveMeItemResult(sender, Result::Err("I'm empty!"))); // Sends an error; TODO: Should handle Result in some way
             return;
         }
 
 
         inventory.take(item);
-        _ = sender.send(InventoryMessage::GiveMeItemResult(Result::Ok(item))); // Sends a tuple containing what item it is and how many it moved; TODO: Should handle Result in some way
+        _ = sending_inventory.send(InventoryMessage::GiveMeItemResult(sender, Result::Ok(item))); // Sends a tuple containing what item it is and how many it moved; TODO: Should handle Result in some way
     }
 
     /// Gets the result from a GiveMeItem message and add the item to this inventory, or prints the
@@ -238,12 +254,19 @@ pub mod inventory {
     /// * 'result'    - A result containing either a tuple of what item was moved and the quantity, 
     ///                 or the error message as a str
     fn give_me_items_result(
+        sender: AID<EntityMessage>,
         inventory: &mut Inventory, 
         result: Result<(Item, usize), &'static str>
     ) {
         match result {
-            Ok(item) => { inventory.give(item) },
-            Err(msg) => { println!("{}", msg) }    // should probably do something else
+            Ok(item) => { 
+                inventory.give(item);
+                _ = sender.send(EntityMessage::InventoryOk); 
+            },
+            Err(msg) => { 
+                println!("{}", msg); // should probably do something else
+                _ = sender.send(EntityMessage::InventoryErr); 
+            }
         };
     }
 
@@ -258,8 +281,9 @@ pub mod inventory {
     /// * 'items'                - Tuple of Item and amount to get
     /// * 'transfer_in_progress' - Bool that is true if there is already a transfer in progress, else false
     fn take_my_items(
+        sender: AID<EntityMessage>,
         inventory: &mut Inventory, 
-        sender: AID<InventoryMessage>, 
+        sending_inventory: AID<InventoryMessage>, 
         items: (Item, usize), 
         // transfer_in_progress: &mut bool
     ) {
@@ -268,11 +292,11 @@ pub mod inventory {
         // }
 
         if inventory.is_full() { // FIXME: this wont happen as is_full is not implemented
-            _ = sender.send(InventoryMessage::TakeMyItemsResult(Result::Err("I'm full!"))); // Sends an error; TODO: Should handle Result in some way
+            _ = sending_inventory.send(InventoryMessage::TakeMyItemsResult(sender.clone(), Result::Err("I'm full!"))); // Sends an error; TODO: Should handle Result in some way
         } 
 
         inventory.give(items);
-        _ = sender.send(InventoryMessage::TakeMyItemsResult(Result::Ok(items)));
+        _ = sending_inventory.send(InventoryMessage::TakeMyItemsResult(sender.clone(), Result::Ok(items)));
     }
 
     /// Gets the result from a TakeMyItems message and removes the items from this inventory, or prints the
@@ -284,12 +308,19 @@ pub mod inventory {
     /// * 'result'    - A result containing either a tuple of what item was moved and the quantity, 
     ///                 or the error message as a str
     fn take_my_items_result(
+        sender: AID<EntityMessage>,
         inventory: &mut Inventory, 
         result: Result<(Item, usize), &'static str>
     ) {
         match result {
-            Ok(item) => { _ = inventory.take(item) },
-            Err(msg) => { println!("{}", msg) }    // should probably do something else
+            Ok(item) => { 
+                _ = inventory.take(item);
+                _ = sender.send(EntityMessage::InventoryOk);
+            },
+            Err(msg) => { 
+                println!("{}", msg); // should probably do something else
+                _ = sender.send(EntityMessage::InventoryErr);
+            }    
         };
     }
 }

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -144,6 +144,7 @@ pub mod inventory {
     /// 
     /// # Arguments
     /// 
+    /// * 'sender'    - AID of entity that sent the Add message
     /// * 'inventory' - Mutable reference to the inventory to increase
     /// * 'item'      - Tuple of Item and amount to take
     fn add(sender: AID<EntityMessage>, inventory: &mut Inventory, item: (Item, usize)) {
@@ -156,6 +157,7 @@ pub mod inventory {
     /// 
     /// # Arguments
     /// 
+    /// * 'sender'    - AID of entity that sent the Remove message
     /// * 'inventory' - Mutable reference to the inventory to take from
     /// * 'item'      - Tuple of Item and amount to take
     fn remove(sender: AID<EntityMessage>, inventory: &mut Inventory, item: (Item, usize)) {
@@ -171,6 +173,7 @@ pub mod inventory {
     /// 
     /// # Arguments
     /// 
+    /// * 'sender'               - AID of entity that sent the TakeFrom message
     /// * 'inventory'            - Reference to the inventory to move item to 
     /// * 'aid'                  - AID of the inventory to take from
     /// * 'items'                - Tuple of Item and amount to take
@@ -195,6 +198,7 @@ pub mod inventory {
     /// 
     /// # Arguments
     /// 
+    /// * 'sender'               - AID of entity that sent the GiveTo message
     /// * 'inventory'            - Reference to the inventory to move item from 
     /// * 'aid'                  - AID of the inventory to give to
     /// * 'items'                - Tuple of Item and amount to give
@@ -219,6 +223,7 @@ pub mod inventory {
     /// 
     /// # Arguments
     /// 
+    /// * 'sender'               - AID of entity that sent the original TakeFrom message
     /// * 'inventory'            - Mutable reference to this inventory
     /// * 'sender'               - AID of the requesting inventory
     /// * 'items'                - Tuple of Item and amount to give
@@ -250,6 +255,7 @@ pub mod inventory {
     /// 
     /// # Arguments
     /// 
+    /// * 'sender'    - AID of entity that sent the original TakeFrom message
     /// * 'inventory' - Mutable reference to this inventory
     /// * 'result'    - A result containing either a tuple of what item was moved and the quantity, 
     ///                 or the error message as a str
@@ -276,6 +282,7 @@ pub mod inventory {
     /// 
     /// # Arguments
     /// 
+    /// * 'sender'               - AID of entity that sent the original GiveTo message
     /// * 'inventory'            - Mutable reference to this inventory
     /// * 'sender'               - AID of the requesting inventory
     /// * 'items'                - Tuple of Item and amount to get
@@ -304,6 +311,7 @@ pub mod inventory {
     /// 
     /// # Arguments
     /// 
+    /// * 'sender'    - AID of entity that sent the original GiveTo message
     /// * 'inventory' - Mutable reference to this inventory
     /// * 'result'    - A result containing either a tuple of what item was moved and the quantity, 
     ///                 or the error message as a str

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -80,255 +80,243 @@ impl Inventory {
     }
 }
 
-pub mod inventory {
-    use crate::{
-        aid::AID, 
-        inventory::{
-            Inventory, 
-            InventoryMessage,
-            Item
-        }, messages::EntityMessage
-    };
+/// Initializes a new inventory and returns its AID
+pub fn init() -> AID<InventoryMessage> {
+    return AID::new(inventory_loop);
+}
+
+fn inventory_loop(
+        aid: AID<InventoryMessage>, 
+        mailbox: std::sync::mpsc::Receiver<InventoryMessage>
+    ){
+    let mut inventory: Inventory = Inventory::construct(aid);
+    // let mut transfer_in_process: bool = false; 
+
+    loop {
+        match mailbox.recv().unwrap() {
+            InventoryMessage::Add(sender, item) => 
+                add(sender, &mut inventory, item),
+
+            InventoryMessage::Remove(sender, item) => 
+                remove(sender, &mut inventory, item),
+
+            InventoryMessage::TakeFrom(sender, other, items) => 
+                take_from(sender, &inventory, other, items, /*&mut transfer_in_process*/),
+
+            InventoryMessage::GiveTo(sender, other, items) => 
+                give_to(sender, &inventory, other, items, /*&mut transfer_in_process*/),
+
+            InventoryMessage::PrintInventory(name) => inventory.print_inv(name),
+            
+            InventoryMessage::Kill => return, 
 
 
-    /// Initializes a new inventory and returns its AID
-    pub fn init() -> AID<InventoryMessage> {
-        return AID::new(inventory_loop);
+
+            InventoryMessage::GiveMeItems(sender, sending_inventory, item) => 
+                give_me_items(sender, &mut inventory, sending_inventory, item, /*&mut transfer_in_process*/),
+
+            InventoryMessage::GiveMeItemResult(sender, result) => {
+                give_me_items_result(sender, &mut inventory, result);
+                // transfer_in_process = false;
+            }
+
+            InventoryMessage::TakeMyItems(sender, sending_inventory, item) => 
+                take_my_items(sender, &mut inventory, sending_inventory, item, /*&mut transfer_in_process*/),
+
+            InventoryMessage::TakeMyItemsResult(sender, result) => 
+                take_my_items_result(sender, &mut inventory, result),
+        };            
     }
+}
 
-    fn inventory_loop(
-            aid: AID<InventoryMessage>, 
-            mailbox: std::sync::mpsc::Receiver<InventoryMessage>
-        ){
-        let mut inventory: Inventory = Inventory::construct(aid);
-        // let mut transfer_in_process: bool = false; 
+/// Gives some count of Item to inventory.
+/// 
+/// # Arguments
+/// 
+/// * 'sender'    - AID of entity that sent the Add message
+/// * 'inventory' - Mutable reference to the inventory to increase
+/// * 'item'      - Tuple of Item and amount to take
+fn add(sender: AID<EntityMessage>, inventory: &mut Inventory, item: (Item, usize)) {
+    // FIXME: INVENTORIES ARE INFINITE FOR FIRST DEMO
+    inventory.give(item);
+    _ = sender.send(EntityMessage::InventoryOk);
+}
 
-        loop {
-            match mailbox.recv().unwrap() {
-                InventoryMessage::Add(sender, item) => 
-                    add(sender, &mut inventory, item),
-
-                InventoryMessage::Remove(sender, item) => 
-                    remove(sender, &mut inventory, item),
-
-                InventoryMessage::TakeFrom(sender, other, items) => 
-                    take_from(sender, &inventory, other, items, /*&mut transfer_in_process*/),
-
-                InventoryMessage::GiveTo(sender, other, items) => 
-                    give_to(sender, &inventory, other, items, /*&mut transfer_in_process*/),
-
-                InventoryMessage::PrintInventory(name) => inventory.print_inv(name),
-                
-                InventoryMessage::Kill => return, 
-
-
-
-                InventoryMessage::GiveMeItems(sender, sending_inventory, item) => 
-                    give_me_items(sender, &mut inventory, sending_inventory, item, /*&mut transfer_in_process*/),
-
-                InventoryMessage::GiveMeItemResult(sender, result) => {
-                    give_me_items_result(sender, &mut inventory, result);
-                    // transfer_in_process = false;
-                }
-
-                InventoryMessage::TakeMyItems(sender, sending_inventory, item) => 
-                    take_my_items(sender, &mut inventory, sending_inventory, item, /*&mut transfer_in_process*/),
-
-                InventoryMessage::TakeMyItemsResult(sender, result) => 
-                    take_my_items_result(sender, &mut inventory, result),
-            };            
-        }
-    }
-
-    /// Gives some count of Item to inventory.
-    /// 
-    /// # Arguments
-    /// 
-    /// * 'sender'    - AID of entity that sent the Add message
-    /// * 'inventory' - Mutable reference to the inventory to increase
-    /// * 'item'      - Tuple of Item and amount to take
-    fn add(sender: AID<EntityMessage>, inventory: &mut Inventory, item: (Item, usize)) {
-        // FIXME: INVENTORIES ARE INFINITE FOR FIRST DEMO
-        inventory.give(item);
+/// Takes some count of Items from inventory, will not do anything if inventory is empty.
+/// 
+/// # Arguments
+/// 
+/// * 'sender'    - AID of entity that sent the Remove message
+/// * 'inventory' - Mutable reference to the inventory to take from
+/// * 'item'      - Tuple of Item and amount to take
+fn remove(sender: AID<EntityMessage>, inventory: &mut Inventory, item: (Item, usize)) {
+    if inventory.take(item) {
         _ = sender.send(EntityMessage::InventoryOk);
     }
 
-    /// Takes some count of Items from inventory, will not do anything if inventory is empty.
-    /// 
-    /// # Arguments
-    /// 
-    /// * 'sender'    - AID of entity that sent the Remove message
-    /// * 'inventory' - Mutable reference to the inventory to take from
-    /// * 'item'      - Tuple of Item and amount to take
-    fn remove(sender: AID<EntityMessage>, inventory: &mut Inventory, item: (Item, usize)) {
-        if inventory.take(item) {
+    _ = sender.send(EntityMessage::InventoryErr);
+}
+
+/// Asks the other inventory to perform the give_me_items function with 
+/// this inventorys AID as 'sender' parameter
+/// 
+/// # Arguments
+/// 
+/// * 'sender'               - AID of entity that sent the TakeFrom message
+/// * 'inventory'            - Reference to the inventory to move item to 
+/// * 'aid'                  - AID of the inventory to take from
+/// * 'items'                - Tuple of Item and amount to take
+/// * 'transfer_in_progress' - Bool that is true if there is already a transfer in progress, else false
+fn take_from(
+    sender: AID<EntityMessage>,
+    inventory: &Inventory, 
+    aid: AID<InventoryMessage>, 
+    item: (Item, usize),
+    // transfer_in_progress: &mut bool
+) {
+    // if *transfer_in_progress /*|| inventory.is_full() */ {
+    //     return; // Should send an error or whatever
+    // }
+
+    // *transfer_in_progress = true;
+    _ = aid.send(InventoryMessage::GiveMeItems(sender, inventory.aid.clone(), item)); // Should handle Result in some way
+}
+
+/// Asks the other inventory to perform the take_my_items function with 
+/// this inventorys AID as 'sender' parameter
+/// 
+/// # Arguments
+/// 
+/// * 'sender'               - AID of entity that sent the GiveTo message
+/// * 'inventory'            - Reference to the inventory to move item from 
+/// * 'aid'                  - AID of the inventory to give to
+/// * 'items'                - Tuple of Item and amount to give
+/// * 'transfer_in_progress' - Bool that is true if there is already a transfer in progress, else false
+fn give_to(
+    sender: AID<EntityMessage>,
+    inventory: &Inventory, 
+    aid: AID<InventoryMessage>, 
+    item: (Item, usize),
+    // transfer_in_progress: &mut bool
+) {
+    // if *transfer_in_progress /*|| inventory.is_full() */ {
+    //     return; // Should send an error or whatever
+    // }
+
+    // *transfer_in_progress = true;
+    _ = aid.send(InventoryMessage::TakeMyItems(sender, inventory.aid.clone(), item));
+}
+
+/// Checks if this inventory can give item and sends a result containing either a tuple containing
+/// what item and quantity, or an error containing a string explaining what went wrong.
+/// 
+/// # Arguments
+/// 
+/// * 'sender'               - AID of entity that sent the original TakeFrom message
+/// * 'inventory'            - Mutable reference to this inventory
+/// * 'sender'               - AID of the requesting inventory
+/// * 'items'                - Tuple of Item and amount to give
+/// * 'transfer_in_progress' - Bool that is true if there is already a transfer in progress, else false
+fn give_me_items(
+    sender: AID<EntityMessage>,
+    inventory: &mut Inventory, 
+    sending_inventory: AID<InventoryMessage>, 
+    item: (Item, usize),
+    // transfer_in_progress: &mut bool
+) {
+    // if *transfer_in_progress {
+    //     _ = sender.send(InventoryMessage::GiveMeItemResult(Result::Err("I'm busy!"))); // Sends an error; TODO: Should handle Result in some way
+    //     return;
+    // }
+
+    if inventory.has_too_few_items(item) {
+        _ = sending_inventory.send(InventoryMessage::GiveMeItemResult(sender, Result::Err("I'm empty!"))); // Sends an error; TODO: Should handle Result in some way
+        return;
+    }
+
+
+    inventory.take(item);
+    _ = sending_inventory.send(InventoryMessage::GiveMeItemResult(sender, Result::Ok(item))); // Sends a tuple containing what item it is and how many it moved; TODO: Should handle Result in some way
+}
+
+/// Gets the result from a GiveMeItem message and add the item to this inventory, or prints the
+/// error message if GiveMeItem failed.
+/// 
+/// # Arguments
+/// 
+/// * 'sender'    - AID of entity that sent the original TakeFrom message
+/// * 'inventory' - Mutable reference to this inventory
+/// * 'result'    - A result containing either a tuple of what item was moved and the quantity, 
+///                 or the error message as a str
+fn give_me_items_result(
+    sender: AID<EntityMessage>,
+    inventory: &mut Inventory, 
+    result: Result<(Item, usize), &'static str>
+) {
+    match result {
+        Ok(item) => { 
+            inventory.give(item);
+            _ = sender.send(EntityMessage::InventoryOk); 
+        },
+        Err(msg) => { 
+            println!("{}", msg); // should probably do something else
+            _ = sender.send(EntityMessage::InventoryErr); 
+        }
+    };
+}
+
+/// Checks if this inventory can take the items and sends a result containing either a tuple 
+/// containing what item and quantity it took, or an error containing a string explaining what 
+/// went wrong.
+/// 
+/// # Arguments
+/// 
+/// * 'sender'               - AID of entity that sent the original GiveTo message
+/// * 'inventory'            - Mutable reference to this inventory
+/// * 'sender'               - AID of the requesting inventory
+/// * 'items'                - Tuple of Item and amount to get
+/// * 'transfer_in_progress' - Bool that is true if there is already a transfer in progress, else false
+fn take_my_items(
+    sender: AID<EntityMessage>,
+    inventory: &mut Inventory, 
+    sending_inventory: AID<InventoryMessage>, 
+    items: (Item, usize), 
+    // transfer_in_progress: &mut bool
+) {
+    // if *transfer_in_progress {
+    //     _ = sender.send(InventoryMessage::TakeMyItemsResult(Result::Err("I'm busy!")));
+    // }
+
+    if inventory.is_full() { // FIXME: this wont happen as is_full is not implemented
+        _ = sending_inventory.send(InventoryMessage::TakeMyItemsResult(sender.clone(), Result::Err("I'm full!"))); // Sends an error; TODO: Should handle Result in some way
+    } 
+
+    inventory.give(items);
+    _ = sending_inventory.send(InventoryMessage::TakeMyItemsResult(sender.clone(), Result::Ok(items)));
+}
+
+/// Gets the result from a TakeMyItems message and removes the items from this inventory, or prints the
+/// error message if TakeMyItems failed.
+/// 
+/// # Arguments
+/// 
+/// * 'sender'    - AID of entity that sent the original GiveTo message
+/// * 'inventory' - Mutable reference to this inventory
+/// * 'result'    - A result containing either a tuple of what item was moved and the quantity, 
+///                 or the error message as a str
+fn take_my_items_result(
+    sender: AID<EntityMessage>,
+    inventory: &mut Inventory, 
+    result: Result<(Item, usize), &'static str>
+) {
+    match result {
+        Ok(item) => { 
+            _ = inventory.take(item);
             _ = sender.send(EntityMessage::InventoryOk);
-        }
-
-        _ = sender.send(EntityMessage::InventoryErr);
-    }
-
-    /// Asks the other inventory to perform the give_me_items function with 
-    /// this inventorys AID as 'sender' parameter
-    /// 
-    /// # Arguments
-    /// 
-    /// * 'sender'               - AID of entity that sent the TakeFrom message
-    /// * 'inventory'            - Reference to the inventory to move item to 
-    /// * 'aid'                  - AID of the inventory to take from
-    /// * 'items'                - Tuple of Item and amount to take
-    /// * 'transfer_in_progress' - Bool that is true if there is already a transfer in progress, else false
-    fn take_from(
-        sender: AID<EntityMessage>,
-        inventory: &Inventory, 
-        aid: AID<InventoryMessage>, 
-        item: (Item, usize),
-        // transfer_in_progress: &mut bool
-    ) {
-        // if *transfer_in_progress /*|| inventory.is_full() */ {
-        //     return; // Should send an error or whatever
-        // }
-
-        // *transfer_in_progress = true;
-        _ = aid.send(InventoryMessage::GiveMeItems(sender, inventory.aid.clone(), item)); // Should handle Result in some way
-    }
-
-    /// Asks the other inventory to perform the take_my_items function with 
-    /// this inventorys AID as 'sender' parameter
-    /// 
-    /// # Arguments
-    /// 
-    /// * 'sender'               - AID of entity that sent the GiveTo message
-    /// * 'inventory'            - Reference to the inventory to move item from 
-    /// * 'aid'                  - AID of the inventory to give to
-    /// * 'items'                - Tuple of Item and amount to give
-    /// * 'transfer_in_progress' - Bool that is true if there is already a transfer in progress, else false
-    fn give_to(
-        sender: AID<EntityMessage>,
-        inventory: &Inventory, 
-        aid: AID<InventoryMessage>, 
-        item: (Item, usize),
-        // transfer_in_progress: &mut bool
-    ) {
-        // if *transfer_in_progress /*|| inventory.is_full() */ {
-        //     return; // Should send an error or whatever
-        // }
-
-        // *transfer_in_progress = true;
-        _ = aid.send(InventoryMessage::TakeMyItems(sender, inventory.aid.clone(), item));
-    }
-
-    /// Checks if this inventory can give item and sends a result containing either a tuple containing
-    /// what item and quantity, or an error containing a string explaining what went wrong.
-    /// 
-    /// # Arguments
-    /// 
-    /// * 'sender'               - AID of entity that sent the original TakeFrom message
-    /// * 'inventory'            - Mutable reference to this inventory
-    /// * 'sender'               - AID of the requesting inventory
-    /// * 'items'                - Tuple of Item and amount to give
-    /// * 'transfer_in_progress' - Bool that is true if there is already a transfer in progress, else false
-    fn give_me_items(
-        sender: AID<EntityMessage>,
-        inventory: &mut Inventory, 
-        sending_inventory: AID<InventoryMessage>, 
-        item: (Item, usize),
-        // transfer_in_progress: &mut bool
-    ) {
-        // if *transfer_in_progress {
-        //     _ = sender.send(InventoryMessage::GiveMeItemResult(Result::Err("I'm busy!"))); // Sends an error; TODO: Should handle Result in some way
-        //     return;
-        // }
-
-        if inventory.has_too_few_items(item) {
-            _ = sending_inventory.send(InventoryMessage::GiveMeItemResult(sender, Result::Err("I'm empty!"))); // Sends an error; TODO: Should handle Result in some way
-            return;
-        }
-
-
-        inventory.take(item);
-        _ = sending_inventory.send(InventoryMessage::GiveMeItemResult(sender, Result::Ok(item))); // Sends a tuple containing what item it is and how many it moved; TODO: Should handle Result in some way
-    }
-
-    /// Gets the result from a GiveMeItem message and add the item to this inventory, or prints the
-    /// error message if GiveMeItem failed.
-    /// 
-    /// # Arguments
-    /// 
-    /// * 'sender'    - AID of entity that sent the original TakeFrom message
-    /// * 'inventory' - Mutable reference to this inventory
-    /// * 'result'    - A result containing either a tuple of what item was moved and the quantity, 
-    ///                 or the error message as a str
-    fn give_me_items_result(
-        sender: AID<EntityMessage>,
-        inventory: &mut Inventory, 
-        result: Result<(Item, usize), &'static str>
-    ) {
-        match result {
-            Ok(item) => { 
-                inventory.give(item);
-                _ = sender.send(EntityMessage::InventoryOk); 
-            },
-            Err(msg) => { 
-                println!("{}", msg); // should probably do something else
-                _ = sender.send(EntityMessage::InventoryErr); 
-            }
-        };
-    }
-
-    /// Checks if this inventory can take the items and sends a result containing either a tuple 
-    /// containing what item and quantity it took, or an error containing a string explaining what 
-    /// went wrong.
-    /// 
-    /// # Arguments
-    /// 
-    /// * 'sender'               - AID of entity that sent the original GiveTo message
-    /// * 'inventory'            - Mutable reference to this inventory
-    /// * 'sender'               - AID of the requesting inventory
-    /// * 'items'                - Tuple of Item and amount to get
-    /// * 'transfer_in_progress' - Bool that is true if there is already a transfer in progress, else false
-    fn take_my_items(
-        sender: AID<EntityMessage>,
-        inventory: &mut Inventory, 
-        sending_inventory: AID<InventoryMessage>, 
-        items: (Item, usize), 
-        // transfer_in_progress: &mut bool
-    ) {
-        // if *transfer_in_progress {
-        //     _ = sender.send(InventoryMessage::TakeMyItemsResult(Result::Err("I'm busy!")));
-        // }
-
-        if inventory.is_full() { // FIXME: this wont happen as is_full is not implemented
-            _ = sending_inventory.send(InventoryMessage::TakeMyItemsResult(sender.clone(), Result::Err("I'm full!"))); // Sends an error; TODO: Should handle Result in some way
-        } 
-
-        inventory.give(items);
-        _ = sending_inventory.send(InventoryMessage::TakeMyItemsResult(sender.clone(), Result::Ok(items)));
-    }
-
-    /// Gets the result from a TakeMyItems message and removes the items from this inventory, or prints the
-    /// error message if TakeMyItems failed.
-    /// 
-    /// # Arguments
-    /// 
-    /// * 'sender'    - AID of entity that sent the original GiveTo message
-    /// * 'inventory' - Mutable reference to this inventory
-    /// * 'result'    - A result containing either a tuple of what item was moved and the quantity, 
-    ///                 or the error message as a str
-    fn take_my_items_result(
-        sender: AID<EntityMessage>,
-        inventory: &mut Inventory, 
-        result: Result<(Item, usize), &'static str>
-    ) {
-        match result {
-            Ok(item) => { 
-                _ = inventory.take(item);
-                _ = sender.send(EntityMessage::InventoryOk);
-            },
-            Err(msg) => { 
-                println!("{}", msg); // should probably do something else
-                _ = sender.send(EntityMessage::InventoryErr);
-            }    
-        };
-    }
+        },
+        Err(msg) => { 
+            println!("{}", msg); // should probably do something else
+            _ = sender.send(EntityMessage::InventoryErr);
+        }    
+    };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,16 +21,16 @@ fn main() {
     test_inventory();
 }
 
-fn do_nothing(aid: aid::AID<EntityMessage>, mailbox: std::sync::mpsc::Receiver<EntityMessage>) {
+fn do_nothing(_aid: aid::AID<EntityMessage>, _mailbox: std::sync::mpsc::Receiver<EntityMessage>) {
     loop {};
 }
 
 fn test_inventory() {
     let sender: aid::AID<EntityMessage> = aid::AID::new(do_nothing);
 
-    let worker_aid: aid::AID<InventoryMessage> = inventory::inventory::init();
-    let factory_aid1: aid::AID<InventoryMessage> = inventory::inventory::init();
-    let factory_aid2: aid::AID<InventoryMessage> = inventory::inventory::init();
+    let worker_aid: aid::AID<InventoryMessage> = inventory::init();
+    let factory_aid1: aid::AID<InventoryMessage> = inventory::init();
+    let factory_aid2: aid::AID<InventoryMessage> = inventory::init();
 
     println!("Creating mutexium in factory 1");
     _ = factory_aid1.send( // Factory 1 produces 8 mutexium

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,24 +14,38 @@ use inventory::{
 
 use item::Item;
 
+use crate::messages::EntityMessage;
+
 fn main() {
     println!("Hello, world!");
     test_inventory();
 }
 
+fn do_nothing(aid: aid::AID<EntityMessage>, mailbox: std::sync::mpsc::Receiver<EntityMessage>) {
+    loop {};
+}
+
 fn test_inventory() {
+    let sender: aid::AID<EntityMessage> = aid::AID::new(do_nothing);
+
     let worker_aid: aid::AID<InventoryMessage> = inventory::inventory::init();
     let factory_aid1: aid::AID<InventoryMessage> = inventory::inventory::init();
     let factory_aid2: aid::AID<InventoryMessage> = inventory::inventory::init();
 
     println!("Creating mutexium in factory 1");
-    _ = factory_aid1.send(InventoryMessage::Add((Item::Semaphorite, 8))); // Factory 1 produces 8 mutexium
+    _ = factory_aid1.send( // Factory 1 produces 8 mutexium
+        InventoryMessage::Add(sender.clone(), (Item::Semaphorite, 8))
+    ); 
     
     println!("Taking 8 mutexium from factory 1 to worker");
-    _ = worker_aid.send(InventoryMessage::TakeFrom(factory_aid1.clone(), (Item::Semaphorite, 8))); // Worker takes 8 Mutexium from factory 1
+    _ = worker_aid.send( // Worker takes 8 Mutexium from factory 1
+        InventoryMessage::TakeFrom(sender.clone(), factory_aid1.clone(), (Item::Semaphorite, 8))
+    ); 
 
     println!("Giving 8 mutexium from worker to factory 2");
-    _ = worker_aid.send(InventoryMessage::GiveTo(factory_aid2.clone(), (Item::Semaphorite, 8))); // Worker gives 8 Mutexium to factory 2
+    _ = worker_aid.send( // Worker gives 8 Mutexium to factory 2
+        InventoryMessage::GiveTo(sender.clone(), factory_aid2.clone(), (Item::Semaphorite, 8))
+    ); 
 
     print_system_status(worker_aid.clone(), factory_aid1.clone(), factory_aid2.clone());
 }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -8,6 +8,8 @@ pub enum EntityMessage {
     KillYourself,
     Ok,
     Err,
+    InventoryOk,
+    InventoryErr,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
Har nu implementerat en väldigt simpel version av svar till requests skickad av entitites. 

De två svarmeddelandena är:
* ```InventoryOk``` - Skickas om en förfrågan lyckades. Det går i dagsläget inte att veta vilket meddelande det syftar på, men det        borde duga för minimum viable product.
* ```InventoryErr``` - Skickas om en förfrågan misslyckades. Likt ```InventoryOk``` säger inte ```InventoryErr``` vad som gick fel, utan det får hanteras någon annanstans.

Alla meddelanden till inventories kräver nu att man skickar med entityns AID så att inventoryt vet var den ska skicka svaret.

Har gjort stubs i buildings.rs för att hantera dessa meddelanden, men de behövs ändras så att de faktiskt gör något.