### PR TITLE
World manager now checks tiles instead of numbers

### DIFF
--- a/src/player_manager.rs
+++ b/src/player_manager.rs
@@ -5,6 +5,7 @@ use ratatui::Frame;
 use ratatui::crossterm::event;
 use ratatui::layout::{Constraint, Layout, Margin, Rect};
 use crossterm::event::{KeyCode};
+use crate::world_manager::Tile;
 
 
 // Temporary values for world size and stuff while integration isn't working
@@ -28,8 +29,7 @@ pub fn render_loop() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn render(frame: &mut Frame) {
-    let mut world_array: [[u32; WIDTH]; HEIGHT] = [[0; WIDTH]; HEIGHT];
-    world_array[2][2] = 1;
+    let world_array: [[Tile; WIDTH]; HEIGHT] = std::array::from_fn(|_| std::array::from_fn(|_| Tile::Empty));
 
     let world_area = frame.area().centered(
                 Length((WIDTH * 2 + 2) as u16),
@@ -55,10 +55,18 @@ fn render(frame: &mut Frame) {
     // TODO: Det här är lätt att förstå men kan vara RUSTigare
     for (row, y) in grid_array.iter().zip(0..HEIGHT) {
         for (cell, x) in row.iter().zip(0..WIDTH) {
-            // TODO: world_array kommer ersättas med messages till world manager?
-            if world_array[y][x] == 1 {
-                let square = Paragraph::new("╔╗\n╚╝").red();
-                frame.render_widget(square, *cell);
+            let tile = &world_array[y][x];
+            // check if tile is empty
+            match tile {
+                Tile::Empty => {}
+                Tile::Worker(_) => {
+                    let square = Paragraph::new("╭╮\n╰╯").blue();
+                    frame.render_widget(square, *cell);
+                }
+                Tile::Building(_) => {
+                    let square = Paragraph::new("╔╗\n╚╝").red();
+                    frame.render_widget(square, *cell);
+                }
             }
         }
     }

--- a/src/world_manager.rs
+++ b/src/world_manager.rs
@@ -21,7 +21,8 @@ pub enum WorldManagerMessage {
 
 pub enum Tile {
     Empty,
-    Entity(AID<EntityMessage>),
+    Worker(AID<EntityMessage>),
+    Building(AID<EntityMessage>),
 }
 
 fn display(grid: &[[Tile; WIDTH]; HEIGHT]) -> String {

--- a/src/world_manager.rs
+++ b/src/world_manager.rs
@@ -19,7 +19,7 @@ pub enum WorldManagerMessage {
     GetDisplay(AID<PlayerManagerMessage>),
 }
 
-enum Tile {
+pub enum Tile {
     Empty,
     Entity(AID<EntityMessage>),
 }


### PR DESCRIPTION
Tile has been changed to have either Empty, Worker or Building. World manager now operates on a 2d array of tiles instead of a 2d array of u32s