### PR TITLE
Add more message variants

### DIFF
--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,7 +1,7 @@
 use crate::aid::AID;
 use crate::inventory::InventoryMessage;
 use crate::item::Item;
-use crate::world_manager::Pos;
+use crate::world_manager::{Pos, Tile, WIDTH, HEIGHT};
 
 #[derive(Clone)]
 pub enum Task {
@@ -46,7 +46,10 @@ pub enum EntityMessage {
 
 #[derive(Clone)]
 pub enum PlayerManagerMessage {
-    TODO,
+    WorldUpdate([[Tile; WIDTH]; HEIGHT]),
+    ShowTileInfo(Pos, Tile),
+    TileNotFound(Pos),
+    Notification(String), // if we ever want to notify the player of anything special
 }
 
 #[derive(Clone)]

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -59,4 +59,5 @@ pub enum PlayerManagerMessage {
 #[derive(Clone)]
 pub enum TaskManagerMessage {
     AssignTask(Task),
+    TaskDone(AID<EntityMessage>, Task),
 }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -59,5 +59,6 @@ pub enum PlayerManagerMessage {
 #[derive(Clone)]
 pub enum TaskManagerMessage {
     AssignTask(Task),
+    RevokeTask(Task),
     TaskDone(AID<EntityMessage>, Task),
 }

--- a/src/player_manager.rs
+++ b/src/player_manager.rs
@@ -5,12 +5,9 @@ use ratatui::Frame;
 use ratatui::crossterm::event;
 use ratatui::layout::{Constraint, Layout, Margin, Rect};
 use crossterm::event::{KeyCode};
-use crate::world_manager::Tile;
+use crate::world_manager::{Tile, WIDTH, HEIGHT};
 
-
-// Temporary values for world size and stuff while integration isn't working
-const WIDTH: usize = 20;
-const HEIGHT: usize = 10;
+// Width and height of a tile on the screen in characters
 const TILE_SIZE: usize = 2;
 
 pub fn render_loop() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/world_manager.rs
+++ b/src/world_manager.rs
@@ -5,8 +5,8 @@ use crate::{
     messages::{EntityMessage, PlayerManagerMessage},
 };
 
-const WIDTH: usize = 16;
-const HEIGHT: usize = 16;
+pub const WIDTH: usize = 16;
+pub const HEIGHT: usize = 16;
 
 pub type Pos = (usize, usize);
 
@@ -19,14 +19,11 @@ pub enum WorldManagerMessage {
     GetDisplay(AID<PlayerManagerMessage>),
 }
 
+#[derive(Clone)]
 pub enum Tile {
     Empty,
     Worker(AID<EntityMessage>),
     Building(AID<EntityMessage>),
-}
-
-fn display(grid: &[[Tile; WIDTH]; HEIGHT]) -> String {
-    return "TODO".to_string();
 }
 
 fn get_tile(grid: &mut [[Tile; WIDTH]; HEIGHT], pos: Pos) -> Option<&mut Tile> {
@@ -46,7 +43,7 @@ pub fn main(_this: AID<WorldManagerMessage>, mailbox: Receiver<WorldManagerMessa
                 if let Some(tile) = get_tile(&mut grid, pos) {
                     // check if pos empty
                     if let Tile::Empty = *tile {
-                        *tile = Tile::Entity(aid.clone());
+                        *tile = Tile::Worker(aid.clone());
                         entity_lookup.insert(aid.clone(), pos);
                         let _ = aid.send(EntityMessage::Ok);
                     } else {
@@ -59,10 +56,10 @@ pub fn main(_this: AID<WorldManagerMessage>, mailbox: Receiver<WorldManagerMessa
             WorldManagerMessage::TileInfo(pos, aid) => {
                 if let Some(tile) = get_tile(&mut grid, pos) {
                     // TODO: send tile
-                    let _ = aid.send(PlayerManagerMessage::TODO);
+                    let _ = aid.send(PlayerManagerMessage::ShowTileInfo(pos, (*tile).clone()));
                 } else {
                     // TODO: send Err
-                    let _ = aid.send(PlayerManagerMessage::TODO);
+                    let _ = aid.send(PlayerManagerMessage::TileNotFound(pos));
                 }
             }
             WorldManagerMessage::KillMe(aid) => {
@@ -75,7 +72,7 @@ pub fn main(_this: AID<WorldManagerMessage>, mailbox: Receiver<WorldManagerMessa
             }
             WorldManagerMessage::GetDisplay(aid) => {
                 // TODO: send display(&grid)
-                let _ = aid.send(PlayerManagerMessage::TODO);
+                let _ = aid.send(PlayerManagerMessage::WorldUpdate(grid.clone()));
             }
         }
     }

--- a/src/world_manager.rs
+++ b/src/world_manager.rs
@@ -56,7 +56,7 @@ pub fn main(_this: AID<WorldManagerMessage>, mailbox: Receiver<WorldManagerMessa
             WorldManagerMessage::TileInfo(pos, aid) => {
                 if let Some(tile) = get_tile(&mut grid, pos) {
                     // TODO: send tile
-                    let _ = aid.send(PlayerManagerMessage::ShowTileInfo(pos, (*tile).clone()));
+                    let _ = aid.send(PlayerManagerMessage::ShowTileInfo(pos, tile.clone()));
                 } else {
                     // TODO: send Err
                     let _ = aid.send(PlayerManagerMessage::TileNotFound(pos));


### PR DESCRIPTION
This PR adds new variants of `PlayerManagerMessage` and `TaskManagerMessage`. Also, it makes it so the `PlayerManagerMessage` variants are used in the relevant places in the `world_manager` module (this PR removes the `TODO` variant).

These types are:
- `PlayerManagerMessage::WorldUpdate(WorldArray)`, sent by the world manager. When the player manager receives this message, it should update the displayed world.
- `PlayerManagerMessage::ShowTileInfo(Pos, Tile)`, sent by the world manager in response to a `TileInfo` request. The player manager can use the contained `Tile` to get information about what exists on that position.
- `PlayerManagerMessage::TileNotFound(Pos)`, sent by the world manager if a nonexistent (out-of-bounds) tile was requested.
- `PlayerManagerMessage::Notification(String)`, sent whenever a notification should appear on the screen.
- `TaskManagerMessage::RevokeTask(Task)`, sent by the player manager when the player requests that a task be stopped.
- `TaskManagerMessage::TaskDone(AID<EntityMessage>, Task)`, sent by an entity once it finishes its current task.

While adding the WorldUpdate message, the constants `WIDTH` and `HEIGHT` have been changed to only be defined in the `world_manager` module, and other modules that defined constants with the same names now instead import them from that module.

Closes #17