### PR TITLE
world manager Move + Place fix

### DIFF
--- a/src/game_manager.rs
+++ b/src/game_manager.rs
@@ -54,7 +54,7 @@ impl GameManager {
         ));
         let _ = self
             .world
-            .send(WorldManagerMessage::Move((10, 3), worker.clone()));
+            .send(WorldManagerMessage::PlaceWorker((10, 3), worker.clone()));
         thread::sleep(Duration::from_secs(1));
         let _ = worker.send(crate::messages::EntityMessage::Task(
             crate::messages::Task::MoveTo((14, 3)),

--- a/src/game_manager.rs
+++ b/src/game_manager.rs
@@ -45,11 +45,16 @@ impl GameManager {
         let building = Building::new(self.world.clone());
         let building2 = Building::new(self.world.clone());
         let worker = Entity::new(self.world.clone(), self.task.clone(), (10, 3));
-        let _ = self.world.send(WorldManagerMessage::Move((3, 3), building.clone()));
         let _ = self
             .world
-            .send(WorldManagerMessage::Move((15, 3), building2.clone()));
-        let _ = self.world.send(WorldManagerMessage::Move((10, 3), worker.clone()));
+            .send(WorldManagerMessage::PlaceBuilding((3, 3), building.clone()));
+        let _ = self.world.send(WorldManagerMessage::PlaceBuilding(
+            (15, 3),
+            building2.clone(),
+        ));
+        let _ = self
+            .world
+            .send(WorldManagerMessage::Move((10, 3), worker.clone()));
         thread::sleep(Duration::from_secs(1));
         let _ = worker.send(crate::messages::EntityMessage::Task(
             crate::messages::Task::MoveTo((14, 3)),

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,11 +1,8 @@
-use crate::{
-    aid::AID,
-    player_manager::WorldArray,
-};
+use crate::aid::AID;
 
 use crate::inventory::InventoryMessage;
 use crate::item::Item;
-use crate::world_manager::{Pos, Tile, WIDTH, HEIGHT};
+use crate::world_manager::{Pos, Tile, WorldGrid};
 
 #[derive(Clone)]
 pub enum Task {
@@ -50,7 +47,7 @@ pub enum EntityMessage {
 
 #[derive(Clone)]
 pub enum PlayerManagerMessage {
-    WorldUpdate(WorldArray),
+    WorldUpdate(WorldGrid),
     ShowTileInfo(Pos, Tile),
     TileNotFound(Pos),
     Notification(String), // if we ever want to notify the player of anything special

--- a/src/player_manager.rs
+++ b/src/player_manager.rs
@@ -1,18 +1,17 @@
 use std::sync::mpsc::Receiver;
 use std::time::Duration;
 
-use ratatui::style::Stylize;
-use ratatui::widgets::{Block, Borders, Paragraph};
-use ratatui::layout::Constraint::Length;
-use ratatui::Frame;
-use ratatui::layout::{Constraint, Layout, Margin, Rect};
-use crossterm::event::{KeyCode, Event, KeyEventKind, read, poll};
 use crate::{
-    world_manager::{Tile, WorldManagerMessage,
-                    WIDTH, HEIGHT},
     aid::AID,
     messages::PlayerManagerMessage,
+    world_manager::{HEIGHT, Tile, WIDTH, WorldGrid, WorldManagerMessage},
 };
+use crossterm::event::{Event, KeyCode, KeyEventKind, poll, read};
+use ratatui::Frame;
+use ratatui::layout::Constraint::Length;
+use ratatui::layout::{Constraint, Layout, Margin, Rect};
+use ratatui::style::Stylize;
+use ratatui::widgets::{Block, Borders, Paragraph};
 
 // Width and height of a tile on the screen in characters
 const TILE_SIZE: usize = 2;
@@ -22,53 +21,56 @@ pub fn render_loop(
     mailbox: Receiver<PlayerManagerMessage>,
     world: AID<WorldManagerMessage>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    ratatui::run(|terminal| loop {
-        let _ = world.send(WorldManagerMessage::GetDisplay(aid.clone()));
+    ratatui::run(|terminal| {
+        loop {
+            let _ = world.send(WorldManagerMessage::GetDisplay(aid.clone()));
 
-        let mut world_array: [[Tile; WIDTH]; HEIGHT] =
-            std::array::from_fn(|_| std::array::from_fn(|_| Tile::Empty));
+            let mut world_array: WorldGrid =
+                std::array::from_fn(|_| std::array::from_fn(|_| Tile::Empty));
 
-        for msg in &mailbox {
-            match msg {
-                PlayerManagerMessage::WorldUpdate(arr) => {
-                    world_array = arr;
-                    let _ = world.send(WorldManagerMessage::GetDisplay(aid.clone()));
-                    break;
+            for msg in &mailbox {
+                match msg {
+                    PlayerManagerMessage::WorldUpdate(arr) => {
+                        world_array = arr;
+                        let _ = world.send(WorldManagerMessage::GetDisplay(aid.clone()));
+                        break;
+                    }
+                    // TODO: Handle more message types
+                    _ => {}
                 }
-                // TODO: Handle more message types
-                _ => {}
             }
-        }
 
-        terminal.draw(|frame| render(frame, world_array))?;
+            terminal.draw(|frame| render(frame, world_array))?;
 
-        if poll(Duration::from_secs(0))? {
-            match read()? {
-                Event::Key(key_event) if key_event.kind == KeyEventKind::Press => {
-                    match key_event.code {
-                        KeyCode::Char('q') => {
-                        break Ok(());
+            if poll(Duration::from_secs(0))? {
+                match read()? {
+                    Event::Key(key_event) if key_event.kind == KeyEventKind::Press => {
+                        match key_event.code {
+                            KeyCode::Char('q') => {
+                                break Ok(());
+                            }
+                            _ => {}
+                        }
                     }
                     _ => {}
-                    }
                 }
-                _ => {}
             }
         }
     })
 }
 
-pub type WorldArray = [[Tile; WIDTH]; HEIGHT];
-
-fn render(frame: &mut Frame, world_array: WorldArray) {
+fn render(frame: &mut Frame, world_array: WorldGrid) {
     let world_area = frame.area().centered(
-                Length((WIDTH * 2 + 2) as u16),
-                Length((HEIGHT * 2 + 2) as u16)
-            );
+        Length((WIDTH * 2 + 2) as u16),
+        Length((HEIGHT * 2 + 2) as u16),
+    );
 
     let grid = world_area.inner(Margin::new(1, 1));
 
-    frame.render_widget(Block::new().borders(Borders::ALL).title("World"), world_area);
+    frame.render_widget(
+        Block::new().borders(Borders::ALL).title("World"),
+        world_area,
+    );
 
     // Vectors av HEIGHT eller WIDTH stycken constraints, alla lika stora som TILE_SIZE
     let row_constraints = (0..HEIGHT).map(|_| Constraint::Length(TILE_SIZE as u16));
@@ -80,7 +82,10 @@ fn render(frame: &mut Frame, world_array: WorldArray) {
 
     // Gör en 2d array av cells
     let rows: Vec<Rect> = grid.layout_vec(&vertical);
-    let grid_array: Vec<Vec<Rect>> = rows.iter().map(|row: &Rect| row.layout_vec(&horizontal)).collect();
+    let grid_array: Vec<Vec<Rect>> = rows
+        .iter()
+        .map(|row: &Rect| row.layout_vec(&horizontal))
+        .collect();
 
     // TODO: Det här är lätt att förstå men kan vara RUSTigare
     for (row, y) in grid_array.iter().zip(0..HEIGHT) {

--- a/src/world_manager.rs
+++ b/src/world_manager.rs
@@ -3,7 +3,6 @@ use std::{collections::HashMap, sync::mpsc::Receiver};
 use crate::{
     aid::AID,
     messages::{EntityMessage, PlayerManagerMessage},
-    player_manager::WorldArray,
 };
 
 pub const WIDTH: usize = 16;
@@ -15,6 +14,7 @@ pub type Pos = (usize, usize);
 pub enum WorldManagerMessage {
     Stop, // is only necessary if there are circular AIDs (which there probably will be)
     Move(Pos, AID<EntityMessage>),
+    PlaceWorker(Pos, AID<EntityMessage>),
     PlaceBuilding(Pos, AID<EntityMessage>),
     KillMe(AID<EntityMessage>),
     TileInfo(Pos, AID<PlayerManagerMessage>),
@@ -28,58 +28,90 @@ pub enum Tile {
     Building(AID<EntityMessage>),
 }
 
-fn get_tile(grid: &mut [[Tile; WIDTH]; HEIGHT], pos: Pos) -> Option<&mut Tile> {
+pub type WorldGrid = [[Tile; WIDTH]; HEIGHT];
+type WorldLookup = HashMap<AID<EntityMessage>, Pos>;
+
+fn get_tile(grid: &mut WorldGrid, pos: Pos) -> Option<&mut Tile> {
     return grid.get_mut(pos.1)?.get_mut(pos.0);
 }
 
+fn place_tile(
+    grid: &mut WorldGrid,
+    entity_lookup: &mut WorldLookup,
+    pos: Pos,
+    aid: AID<EntityMessage>,
+    tile: Tile,
+) {
+    // check that it does not already have a position
+    if let None = entity_lookup.get(&aid) {
+        // check if pos in bounds
+        if let Some(dest) = get_tile(grid, pos) {
+            // check if pos empty
+            if let Tile::Empty = *dest {
+                *dest = tile;
+                // send early to not have to clone aid again
+                let _ = aid.send(EntityMessage::Ok);
+                entity_lookup.insert(aid, pos);
+                return;
+            }
+        }
+    }
+
+    let _ = aid.send(EntityMessage::Err);
+}
+
+fn move_tile(
+    grid: &mut WorldGrid,
+    entity_lookup: &mut WorldLookup,
+    pos: Pos,
+    aid: AID<EntityMessage>,
+) {
+    // check if pos is valid
+    if let Some(dest) = get_tile(grid, pos) {
+        if let Tile::Empty = *dest {
+            if let Some(old_pos) = entity_lookup.get(&aid) {
+                // all positions in entity_lookup are valid so unwrap will never panic
+                let old_tile = get_tile(grid, *old_pos).unwrap();
+                let temp = old_tile.clone();
+                *old_tile = Tile::Empty;
+
+                // already checked that pos is valid so unwrap will never panic
+                *get_tile(grid, pos).unwrap() = temp;
+                // send early to not have to clone aid again
+                let _ = aid.send(EntityMessage::Ok);
+                entity_lookup.insert(aid, pos);
+                return;
+            }
+        }
+    }
+
+    let _ = aid.send(EntityMessage::Err);
+}
+
 pub fn main(_this: AID<WorldManagerMessage>, mailbox: Receiver<WorldManagerMessage>) {
-    let mut grid: WorldArray = std::array::from_fn(|_| std::array::from_fn(|_| Tile::Empty));
-    let mut entity_lookup: HashMap<AID<EntityMessage>, Pos> = HashMap::new();
+    let mut grid: WorldGrid = std::array::from_fn(|_| std::array::from_fn(|_| Tile::Empty));
+    let mut entity_lookup: WorldLookup = HashMap::new();
 
     for msg in mailbox {
         match msg {
             WorldManagerMessage::Stop => break,
             WorldManagerMessage::Move(pos, aid) => {
-                // check if pos in bounds
-                if let Some(tile) = get_tile(&mut grid, pos) {
-                    // check if pos empty
-                    if let Tile::Empty = *tile {
-                        *tile = Tile::Worker(aid.clone());
-                        let old_pos = entity_lookup.insert(aid.clone(), pos);
-                        // remove from old pos if it had one
-                        if let Some(old_pos) = old_pos {
-                            if let Some(old_tile) = get_tile(&mut grid, old_pos) {
-                                *old_tile = Tile::Empty;
-                            }
-                        }
-                        let _ = aid.send(EntityMessage::Ok);
-                    } else {
-                        let _ = aid.send(EntityMessage::Err);
-                    }
-                } else {
-                    let _ = aid.send(EntityMessage::Err);
-                }
+                move_tile(&mut grid, &mut entity_lookup, pos, aid)
             }
-            WorldManagerMessage::PlaceBuilding(pos, aid) => {
-                // check that it does not already have a position
-                if let None = entity_lookup.get(&aid) {
-                    // check if pos in bounds
-                    if let Some(tile) = get_tile(&mut grid, pos) {
-                        // check if pos empty
-                        if let Tile::Empty = *tile {
-                            *tile = Tile::Building(aid.clone());
-                            entity_lookup.insert(aid.clone(), pos);
-                            let _ = aid.send(EntityMessage::Ok);
-                        } else {
-                            let _ = aid.send(EntityMessage::Err);
-                        }
-                    } else {
-                        let _ = aid.send(EntityMessage::Err);
-                    }
-                } else {
-                    let _ = aid.send(EntityMessage::Err);
-                }
-            }
+            WorldManagerMessage::PlaceWorker(pos, aid) => place_tile(
+                &mut grid,
+                &mut entity_lookup,
+                pos,
+                aid.clone(),
+                Tile::Worker(aid),
+            ),
+            WorldManagerMessage::PlaceBuilding(pos, aid) => place_tile(
+                &mut grid,
+                &mut entity_lookup,
+                pos,
+                aid.clone(),
+                Tile::Building(aid),
+            ),
             WorldManagerMessage::TileInfo(pos, aid) => {
                 if let Some(tile) = get_tile(&mut grid, pos) {
                     let _ = aid.send(PlayerManagerMessage::ShowTileInfo(pos, tile.clone()));

--- a/src/world_manager.rs
+++ b/src/world_manager.rs
@@ -2,7 +2,8 @@ use std::{collections::HashMap, sync::mpsc::Receiver};
 
 use crate::{
     aid::AID,
-    messages::{EntityMessage, PlayerManagerMessage}, player_manager::WorldArray,
+    messages::{EntityMessage, PlayerManagerMessage},
+    player_manager::WorldArray,
 };
 
 pub const WIDTH: usize = 16;
@@ -14,6 +15,7 @@ pub type Pos = (usize, usize);
 pub enum WorldManagerMessage {
     Stop, // is only necessary if there are circular AIDs (which there probably will be)
     Move(Pos, AID<EntityMessage>),
+    PlaceBuilding(Pos, AID<EntityMessage>),
     KillMe(AID<EntityMessage>),
     TileInfo(Pos, AID<PlayerManagerMessage>),
     GetDisplay(AID<PlayerManagerMessage>),
@@ -31,8 +33,7 @@ fn get_tile(grid: &mut [[Tile; WIDTH]; HEIGHT], pos: Pos) -> Option<&mut Tile> {
 }
 
 pub fn main(_this: AID<WorldManagerMessage>, mailbox: Receiver<WorldManagerMessage>) {
-    let mut grid: WorldArray =
-        std::array::from_fn(|_| std::array::from_fn(|_| Tile::Empty));
+    let mut grid: WorldArray = std::array::from_fn(|_| std::array::from_fn(|_| Tile::Empty));
     let mut entity_lookup: HashMap<AID<EntityMessage>, Pos> = HashMap::new();
 
     for msg in mailbox {
@@ -44,8 +45,34 @@ pub fn main(_this: AID<WorldManagerMessage>, mailbox: Receiver<WorldManagerMessa
                     // check if pos empty
                     if let Tile::Empty = *tile {
                         *tile = Tile::Worker(aid.clone());
-                        entity_lookup.insert(aid.clone(), pos);
+                        let old_pos = entity_lookup.insert(aid.clone(), pos);
+                        // remove from old pos if it had one
+                        if let Some(old_pos) = old_pos {
+                            if let Some(old_tile) = get_tile(&mut grid, old_pos) {
+                                *old_tile = Tile::Empty;
+                            }
+                        }
                         let _ = aid.send(EntityMessage::Ok);
+                    } else {
+                        let _ = aid.send(EntityMessage::Err);
+                    }
+                } else {
+                    let _ = aid.send(EntityMessage::Err);
+                }
+            }
+            WorldManagerMessage::PlaceBuilding(pos, aid) => {
+                // check that it does not already have a position
+                if let None = entity_lookup.get(&aid) {
+                    // check if pos in bounds
+                    if let Some(tile) = get_tile(&mut grid, pos) {
+                        // check if pos empty
+                        if let Tile::Empty = *tile {
+                            *tile = Tile::Building(aid.clone());
+                            entity_lookup.insert(aid.clone(), pos);
+                            let _ = aid.send(EntityMessage::Ok);
+                        } else {
+                            let _ = aid.send(EntityMessage::Err);
+                        }
                     } else {
                         let _ = aid.send(EntityMessage::Err);
                     }
@@ -55,10 +82,8 @@ pub fn main(_this: AID<WorldManagerMessage>, mailbox: Receiver<WorldManagerMessa
             }
             WorldManagerMessage::TileInfo(pos, aid) => {
                 if let Some(tile) = get_tile(&mut grid, pos) {
-                    // TODO: send tile
                     let _ = aid.send(PlayerManagerMessage::ShowTileInfo(pos, tile.clone()));
                 } else {
-                    // TODO: send Err
                     let _ = aid.send(PlayerManagerMessage::TileNotFound(pos));
                 }
             }
@@ -71,7 +96,6 @@ pub fn main(_this: AID<WorldManagerMessage>, mailbox: Receiver<WorldManagerMessa
                 // no response necessary
             }
             WorldManagerMessage::GetDisplay(aid) => {
-                // TODO: send display(&grid)
                 let _ = aid.send(PlayerManagerMessage::WorldUpdate(grid.clone()));
             }
         }


### PR DESCRIPTION
resolves #39 

Lade till PlaceWorker och PlaceBuilding i WorldManagerMessage för att kunna skilja på arbetare och byggnader. Ändrade också i game manager för att använda dessa.

Fixade Move i world manager så den tar bort från förra positionen.

Små refactors som inkluderar:
* flyttade WorldArray typen till world_manager.rs och döpte om den till WorldGrid.
* skapade privata typen WorldLookup för att matcha WorldArray och slippa skriva hela typen.
* flyttade logiken för world manager Move, PlaceWorker och PlaceBuilding till privata hjälpfunktioner