### PR TITLE
Stores the world grid on the heap

### DIFF
--- a/src/game_manager.rs
+++ b/src/game_manager.rs
@@ -6,7 +6,7 @@ use crate::{
     entity::Entity,
     messages::{PlayerManagerMessage, TaskManagerMessage},
     player_manager,
-    world_manager::{self, WorldManagerMessage},
+    world_manager::{self, WorldManagerMessage, init_world_grid},
 };
 
 pub struct GameManager {
@@ -17,12 +17,18 @@ pub struct GameManager {
 
 impl GameManager {
     pub fn new() -> Self {
-        let world = AID::new(world_manager::main);
+        let grid = init_world_grid();
+
+        let world = AID::new({
+            let grid = grid.clone();
+            |aid, mailbox| world_manager::main(aid, mailbox, grid)
+        });
         let task = AID::new(|_, _| {});
         let player = AID::new({
             let world = world.clone();
-            move |aid, mailbox| {
-                let _ = player_manager::render_loop(aid, mailbox, world);
+            let grid = grid.clone();
+            |aid, mailbox| {
+                player_manager::render_loop(aid, mailbox, world, grid);
             }
         });
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -47,7 +47,6 @@ pub enum EntityMessage {
 
 #[derive(Clone)]
 pub enum PlayerManagerMessage {
-    WorldUpdate(WorldGrid),
     ShowTileInfo(Pos, Tile),
     TileNotFound(Pos),
     Notification(String), // if we ever want to notify the player of anything special

--- a/src/player_manager.rs
+++ b/src/player_manager.rs
@@ -20,29 +20,21 @@ pub fn render_loop(
     aid: AID<PlayerManagerMessage>,
     mailbox: Receiver<PlayerManagerMessage>,
     world: AID<WorldManagerMessage>,
+    world_array: WorldGrid,
 ) -> Result<(), Box<dyn std::error::Error>> {
     ratatui::run(|terminal| {
         loop {
-            let _ = world.send(WorldManagerMessage::GetDisplay(aid.clone()));
-
-            let mut world_array: WorldGrid =
-                std::array::from_fn(|_| std::array::from_fn(|_| Tile::Empty));
-
-            for msg in &mailbox {
+            //read all messages in mailbox
+            while let Ok(msg) = mailbox.try_recv() {
                 match msg {
-                    PlayerManagerMessage::WorldUpdate(arr) => {
-                        world_array = arr;
-                        let _ = world.send(WorldManagerMessage::GetDisplay(aid.clone()));
-                        break;
-                    }
                     // TODO: Handle more message types
                     _ => {}
                 }
             }
 
-            terminal.draw(|frame| render(frame, world_array))?;
+            terminal.draw(|frame| render(frame, &world_array))?;
 
-            if poll(Duration::from_secs(0))? {
+            if poll(Duration::from_millis(30))? {
                 match read()? {
                     Event::Key(key_event) if key_event.kind == KeyEventKind::Press => {
                         match key_event.code {
@@ -59,7 +51,7 @@ pub fn render_loop(
     })
 }
 
-fn render(frame: &mut Frame, world_array: WorldGrid) {
+fn render(frame: &mut Frame, world_array: &WorldGrid) {
     let world_area = frame.area().centered(
         Length((WIDTH * 2 + 2) as u16),
         Length((HEIGHT * 2 + 2) as u16),
@@ -86,6 +78,9 @@ fn render(frame: &mut Frame, world_array: WorldGrid) {
         .iter()
         .map(|row: &Rect| row.layout_vec(&horizontal))
         .collect();
+
+    // aquire lock until it falls out of scope
+    let world_array = &world_array.lock().unwrap();
 
     // TODO: Det här är lätt att förstå men kan vara RUSTigare
     for (row, y) in grid_array.iter().zip(0..HEIGHT) {

--- a/src/world_manager.rs
+++ b/src/world_manager.rs
@@ -1,12 +1,18 @@
-use std::{collections::HashMap, sync::mpsc::Receiver};
+use std::{
+    collections::HashMap,
+    mem::MaybeUninit,
+    ptr,
+    sync::{Arc, Mutex, mpsc::Receiver},
+    vec,
+};
 
 use crate::{
     aid::AID,
     messages::{EntityMessage, PlayerManagerMessage},
 };
 
-pub const WIDTH: usize = 32;
-pub const HEIGHT: usize = 16;
+pub const WIDTH: usize = 50;
+pub const HEIGHT: usize = 30;
 
 pub type Pos = (usize, usize);
 
@@ -18,7 +24,6 @@ pub enum WorldManagerMessage {
     PlaceBuilding(Pos, AID<EntityMessage>),
     KillMe(AID<EntityMessage>),
     TileInfo(Pos, AID<PlayerManagerMessage>),
-    GetDisplay(AID<PlayerManagerMessage>),
 }
 
 #[derive(Clone)]
@@ -28,20 +33,27 @@ pub enum Tile {
     Building(AID<EntityMessage>),
 }
 
-pub type WorldGrid = [[Tile; WIDTH]; HEIGHT];
 type WorldLookup = HashMap<AID<EntityMessage>, Pos>;
+type RawWorldArray = Vec<Vec<Tile>>;
+pub type WorldGrid = Arc<Mutex<RawWorldArray>>;
 
-fn get_tile(grid: &mut WorldGrid, pos: Pos) -> Option<&mut Tile> {
+pub fn init_world_grid() -> WorldGrid {
+    return Arc::new(Mutex::new(vec![vec![Tile::Empty; WIDTH]; HEIGHT]));
+}
+
+fn get_tile(grid: &mut RawWorldArray, pos: Pos) -> Option<&mut Tile> {
     return grid.get_mut(pos.1)?.get_mut(pos.0);
 }
 
 fn place_tile(
-    grid: &mut WorldGrid,
+    grid: &WorldGrid,
     entity_lookup: &mut WorldLookup,
     pos: Pos,
     aid: AID<EntityMessage>,
     tile: Tile,
 ) {
+    let grid = &mut grid.lock().unwrap();
+
     // check that it does not already have a position
     if let None = entity_lookup.get(&aid) {
         // check if pos in bounds
@@ -60,12 +72,9 @@ fn place_tile(
     let _ = aid.send(EntityMessage::Err);
 }
 
-fn move_tile(
-    grid: &mut WorldGrid,
-    entity_lookup: &mut WorldLookup,
-    pos: Pos,
-    aid: AID<EntityMessage>,
-) {
+fn move_tile(grid: &WorldGrid, entity_lookup: &mut WorldLookup, pos: Pos, aid: AID<EntityMessage>) {
+    let grid = &mut grid.lock().unwrap();
+
     // check if pos is valid
     if let Some(dest) = get_tile(grid, pos) {
         if let Tile::Empty = *dest {
@@ -88,47 +97,49 @@ fn move_tile(
     let _ = aid.send(EntityMessage::Err);
 }
 
-pub fn main(_this: AID<WorldManagerMessage>, mailbox: Receiver<WorldManagerMessage>) {
-    let mut grid: WorldGrid = std::array::from_fn(|_| std::array::from_fn(|_| Tile::Empty));
+pub fn main(
+    _this: AID<WorldManagerMessage>,
+    mailbox: Receiver<WorldManagerMessage>,
+    grid: WorldGrid,
+) {
     let mut entity_lookup: WorldLookup = HashMap::new();
 
     for msg in mailbox {
         match msg {
             WorldManagerMessage::Stop => break,
-            WorldManagerMessage::Move(pos, aid) => {
-                move_tile(&mut grid, &mut entity_lookup, pos, aid)
-            }
+            WorldManagerMessage::Move(pos, aid) => move_tile(&grid, &mut entity_lookup, pos, aid),
             WorldManagerMessage::PlaceWorker(pos, aid) => place_tile(
-                &mut grid,
+                &grid,
                 &mut entity_lookup,
                 pos,
                 aid.clone(),
                 Tile::Worker(aid),
             ),
             WorldManagerMessage::PlaceBuilding(pos, aid) => place_tile(
-                &mut grid,
+                &grid,
                 &mut entity_lookup,
                 pos,
                 aid.clone(),
                 Tile::Building(aid),
             ),
             WorldManagerMessage::TileInfo(pos, aid) => {
-                if let Some(tile) = get_tile(&mut grid, pos) {
+                let grid = &mut grid.lock().unwrap();
+
+                if let Some(tile) = get_tile(grid, pos) {
                     let _ = aid.send(PlayerManagerMessage::ShowTileInfo(pos, tile.clone()));
                 } else {
                     let _ = aid.send(PlayerManagerMessage::TileNotFound(pos));
                 }
             }
             WorldManagerMessage::KillMe(aid) => {
+                let grid = &mut grid.lock().unwrap();
+
                 if let Some(pos) = entity_lookup.remove(&aid) {
-                    if let Some(tile) = get_tile(&mut grid, pos) {
+                    if let Some(tile) = get_tile(grid, pos) {
                         *tile = Tile::Empty;
                     }
                 }
                 // no response necessary
-            }
-            WorldManagerMessage::GetDisplay(aid) => {
-                let _ = aid.send(PlayerManagerMessage::WorldUpdate(grid.clone()));
             }
         }
     }


### PR DESCRIPTION
resolves #42 

The world grid is now an arc mutex of 2d vectors. This allows it to become much larger without triggering stack overflow.

The player manager no longer sends a message to request the state. It instead holds a reference to the memory directly.

The world grid is initialized by the game manager and passed to both the game manager and player manager directly.