### PR TITLE
Simple pathfinding

### DIFF
--- a/src/entity.rs
+++ b/src/entity.rs
@@ -4,9 +4,8 @@ use crate::item::Item;
 use crate::messages::EntityMessage;
 use crate::task_manager::{Task, TaskManagerMessage};
 use crate::world_manager::{Pos, WorldManagerMessage};
-use std::cmp::{max, min};
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::sync::mpsc::{Receiver, sync_channel};
+use std::sync::mpsc::Receiver;
 use std::thread;
 use std::time::Duration;
 
@@ -48,21 +47,9 @@ enum Request {
     TakeItem(Item),
 }
 
-fn abs_sub(a: usize, b: usize) -> usize {
-    return max(a, b) - min(a, b);
-}
-
-// |x2 - x1| + |y2 - y1|
-#[allow(unused)]
-fn manhattan_distance(from: Pos, to: Pos) -> usize {
-    return abs_sub(from.0, to.0) + abs_sub(from.1, to.1);
-}
-
-// (x2 - x1)^2 + (y2 - y1)^2
+// nicer to keep it squared to avaoid roots and floats
 fn euclidean_distance_squared(from: Pos, to: Pos) -> usize {
-    let dx = abs_sub(from.0, to.0);
-    let dy = abs_sub(from.1, to.1);
-    return dx * dx + dy * dy;
+    return from.0.abs_diff(to.0).pow(2) + from.1.abs_diff(to.1).pow(2);
 }
 
 // Returns a set of all adjacent positions

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -4,10 +4,16 @@ use crate::item::Item;
 use crate::messages::EntityMessage;
 use crate::task_manager::{Task, TaskManagerMessage};
 use crate::world_manager::{Pos, WorldManagerMessage};
-use std::collections::VecDeque;
-use std::sync::mpsc::Receiver;
+use std::cmp::{max, min};
+use std::collections::{HashSet, VecDeque};
+use std::sync::mpsc::{Receiver, sync_channel};
 use std::thread;
 use std::time::Duration;
+
+// duration to wait after moving
+const MOVE_TIME: Duration = Duration::from_millis(250);
+// duration to wait after transferring items
+const TRANSFER_TIME: Duration = Duration::from_millis(1500);
 
 /// Ren logik- och state för en entity.
 ///
@@ -15,6 +21,7 @@ use std::time::Duration;
 /// - att hålla nuvarande position (`current_pos`)
 /// - att lagra en väntande flytt (`pending_move`)
 /// - att behandla inkommande tasks
+/// - att lagra state för pathfinding
 /// - att uppdatera state baserat på Ok/Err från WorldManager
 ///
 /// Innehåller ingen actor‑logik.
@@ -24,6 +31,10 @@ struct EntityCore {
     current_pos: Pos,
     pending_move: Option<Pos>,
     sub_tasks: VecDeque<SubTask>,
+    open_neighbors: HashSet<Pos>,
+    pathfinding_state: PathfindingState,
+    next_pathfinding_state: Option<PathfindingState>,
+    visited_states: HashSet<(Pos, PathfindingState)>,
 }
 
 enum SubTask {
@@ -39,6 +50,100 @@ enum Request {
     TakeItem(Item),
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+enum Dir {
+    Up,
+    Right,
+    Down,
+    Left,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+enum PathfindingState {
+    ProductivePath,
+    HandRule(usize, Dir),
+}
+
+const DEFAULT_PATHFINDING_STATE: PathfindingState = PathfindingState::ProductivePath;
+
+fn abs_sub(a: usize, b: usize) -> usize {
+    return max(a, b) - min(a, b);
+}
+
+// dx + dy
+fn manhattan_distance(from: Pos, to: Pos) -> usize {
+    return abs_sub(from.0, to.0) + abs_sub(from.1, to.1);
+}
+
+// approximate the direction between to points
+fn dir_towards_pos(from: Pos, to: Pos) -> Option<Dir> {
+    return if abs_sub(from.0, to.0) >= abs_sub(from.1, to.1) {
+        if from.0 < to.0 {
+            Some(Dir::Right)
+        } else if from.0 > to.0 {
+            Some(Dir::Left)
+        } else {
+            None
+        }
+    } else {
+        if from.1 < to.1 {
+            Some(Dir::Down)
+        } else if from.1 > to.1 {
+            Some(Dir::Up)
+        } else {
+            None
+        }
+    };
+}
+
+// The counter clockwise angle between two directions in quarter turns
+fn dir_angle(from: Dir, to: Dir) -> usize {
+    let from = match from {
+        Dir::Up => 0,
+        Dir::Left => 1,
+        Dir::Down => 2,
+        Dir::Right => 3,
+    };
+    let to = match to {
+        Dir::Up => 0,
+        Dir::Left => 1,
+        Dir::Down => 2,
+        Dir::Right => 3,
+    };
+    return (4 + to - from) % 4;
+}
+
+// Rotate direction counter clockwise by angle in quarter turns
+fn rotate_dir(dir: Dir, angle: usize) -> Dir {
+    let dir = match dir {
+        Dir::Up => 0,
+        Dir::Left => 1,
+        Dir::Down => 2,
+        Dir::Right => 3,
+    };
+    match (dir + angle) % 4 {
+        0 => Dir::Up,
+        1 => Dir::Left,
+        2 => Dir::Down,
+        3 => Dir::Right,
+        _ => unreachable!(),
+    }
+}
+
+// Returns a set of all adjacent positions
+fn neighbors(pos: Pos) -> HashSet<Pos> {
+    let mut set = HashSet::new();
+    set.insert((pos.0 + 1, pos.1));
+    set.insert((pos.0, pos.1 + 1));
+    if pos.0 > 0 {
+        set.insert((pos.0 - 1, pos.1));
+    }
+    if pos.1 > 0 {
+        set.insert((pos.0, pos.1 - 1));
+    }
+    return set;
+}
+
 #[allow(dead_code)]
 impl EntityCore {
     // skapar en EntityCore  med given start position
@@ -47,38 +152,100 @@ impl EntityCore {
             current_pos: start_pos,
             pending_move: None,
             sub_tasks: VecDeque::new(),
+            open_neighbors: neighbors(start_pos),
+            pathfinding_state: DEFAULT_PATHFINDING_STATE,
+            next_pathfinding_state: None,
+            visited_states: HashSet::new(),
         }
     }
 
-    fn process_move(&mut self, pos: Pos) -> Option<Pos> {
-        let mut return_pos: Option<Pos> = None;
+    fn pathfind(&mut self, dst: Pos) -> Option<(Pos, PathfindingState)> {
+        // algorithm from https://en.wikipedia.org/wiki/Maze-solving_algorithm#Maze-routing_algorithm
 
-        if pos.0 > self.current_pos.0 {
-            return_pos = Some((self.current_pos.0 + 1, self.current_pos.1));
-        } else if pos.0 < self.current_pos.0 {
-            return_pos = Some((self.current_pos.0 - 1, self.current_pos.1));
-        } else if pos.1 > self.current_pos.1 {
-            return_pos = Some((self.current_pos.0, self.current_pos.1 + 1));
-        } else if pos.1 < self.current_pos.1 {
-            return_pos = Some((self.current_pos.0, self.current_pos.1 - 1));
-        } else {
-            self.sub_tasks.pop_front();
+        let cur = self.current_pos;
+        let md_cur = manhattan_distance(cur, dst);
+
+        if cur == dst {
+            return None;
         }
-        self.pending_move = return_pos;
-        return return_pos;
+
+        // preferred_dir is direction towards dst if in ProductivePath state
+        // or to the right of facing_dir if in HandRule state
+        let (md_best, preferred_dir) = match self.pathfinding_state {
+            // unwrap will never panic since cur != dst
+            PathfindingState::ProductivePath => (md_cur, dir_towards_pos(cur, dst).unwrap()),
+            PathfindingState::HandRule(md_best, facing_dir) => (md_best, rotate_dir(facing_dir, 3)),
+        };
+
+        let mut path: Option<Pos> = None;
+
+        // try taking productive path if at closest distance
+        if md_cur <= md_best {
+            for neighbor in self.open_neighbors.iter() {
+                if manhattan_distance(*neighbor, dst) < md_cur
+                    && (path.is_none()
+                        // prioritize moving in the dimension with largest difference
+                        || dir_towards_pos(cur, *neighbor) == dir_towards_pos(cur, dst))
+                {
+                    path = Some(*neighbor);
+                }
+            }
+        }
+
+        if let Some(path_pos) = path {
+            // productive path found, enter ProductivePath state
+            return Some((path_pos, PathfindingState::ProductivePath));
+        }
+        // no productive path exists
+
+        // (next pos, dir to next pos, angle between preferred_dir and dir to next pos)
+        let mut path: Option<(Pos, Dir, usize)> = None;
+
+        for neighbor in self.open_neighbors.iter() {
+            // get direction to neighbor and its angle to preferred_dir
+            // unwrap will never panic since cur != *nieghbor
+            let neighbor_dir = dir_towards_pos(cur, *neighbor).unwrap();
+            let neighbor_angle = dir_angle(preferred_dir, neighbor_dir);
+            if let Some((_, _, path_angle)) = path {
+                // Take the first path ccw of preferred_dir (including preferred_dir itself)
+                if neighbor_angle < path_angle {
+                    path = Some((*neighbor, neighbor_dir, neighbor_angle));
+                }
+            } else {
+                // If no other path found yet, take this one
+                path = Some((*neighbor, neighbor_dir, neighbor_angle));
+            }
+        }
+
+        if let Some((path_pos, path_dir, _)) = path {
+            // no productive path found, enter HandRule state
+            return Some((
+                path_pos,
+                PathfindingState::HandRule(min(md_cur, md_best), path_dir),
+            ));
+        } else {
+            // completely stuck
+            return None;
+        }
     }
 
     fn process_task(&mut self) -> Option<Request> {
-        if self.sub_tasks.is_empty() {
-            return Some(Request::RequestTask);
-        }
         if let Some(sub_task) = self.sub_tasks.front() {
             match sub_task {
                 SubTask::Move(pos) => {
-                    if let Some(target) = self.process_move(*pos) {
+                    if *pos == self.current_pos {
+                        self.sub_tasks.pop_front();
+                        return None;
+                    }
+
+                    if let Some((target, state)) = self.pathfind(*pos) {
+                        self.pending_move = Some(target);
+                        self.next_pathfinding_state = Some(state);
                         return Some(Request::Move(target));
                     } else {
-                        //
+                        // completely stuck
+                        // wait a bit and hope something has moved until next iteration
+                        thread::sleep(MOVE_TIME);
                         return None;
                     }
                 }
@@ -89,23 +256,24 @@ impl EntityCore {
                     return Some(Request::TakeItem(*item));
                 }
             }
+        } else {
+            return Some(Request::RequestTask);
         }
-        return None;
     }
 
     /// Behandlar en Task och returnerar eventuell Move-position
     /// som Entity-aktorn ska skicka till WorldManager.
-    fn new_task(&mut self, task: Task) {   
+    fn new_task(&mut self, task: Task) {
         match task {
             Task::MoveTo(pos) => {
                 self.sub_tasks.push_back(SubTask::Move(pos));
             }
-            Task::DeliverItem(item,from, to) => {
+            Task::DeliverItem(item, from, to) => {
                 self.sub_tasks.push_back(SubTask::Move(from));
                 self.sub_tasks.push_back(SubTask::TakeItem(item));
                 self.sub_tasks.push_back(SubTask::Move(to));
                 self.sub_tasks.push_back(SubTask::GiveItem(item));
-            },
+            }
             _ => (),
             // Task::AddItem { .. } => {
             //     self.is_busy = true;
@@ -133,13 +301,31 @@ impl EntityCore {
     fn apply_ok(&mut self) {
         if let Some(pos) = self.pending_move.take() {
             self.current_pos = pos;
-            self.pending_move = None;
+            // recalculate neighbors
+            self.open_neighbors = neighbors(pos);
+
+            // move successful, update state
+            if let Some(state) = self.next_pathfinding_state.take() {
+                // since walls can move, the algorithm can get stuck in a loop, if that happens, restart the algorithm by clearing its memory
+                if !self.visited_states.insert((pos, state)) {
+                    self.visited_states.clear();
+                    self.pathfinding_state = DEFAULT_PATHFINDING_STATE;
+                } else {
+                    self.pathfinding_state = state;
+                }
+            }
         }
     }
     /// Anropas när WorldManager nekar en flytt.
     /// Tömmer pending_move utan att ändra current_pos.
     fn apply_err(&mut self) {
-        self.pending_move = None;
+        if let Some(pos) = self.pending_move.take() {
+            // pos is not open
+            self.open_neighbors.remove(&pos);
+        }
+
+        // move unsuccessful, next state is invalid
+        self.next_pathfinding_state = None;
     }
 }
 
@@ -155,6 +341,7 @@ impl EntityCore {
 /// Entity själv hanterar endast actor‑beteende och message‑flow.
 pub struct Entity {
     core: EntityCore,
+    alive: bool,
     waiting: bool,
     world_aid: AID<WorldManagerMessage>,
     task_aid: AID<TaskManagerMessage>,
@@ -183,6 +370,7 @@ impl Entity {
     ) -> Self {
         Entity {
             core: EntityCore::new(start_pos),
+            alive: true,
             waiting: false,
             world_aid: world,
             task_aid: task,
@@ -191,50 +379,61 @@ impl Entity {
         }
     }
 
+    fn msg_handler(&mut self, msg: EntityMessage) {
+        match msg {
+            EntityMessage::Task(task) => {
+                self.core.new_task(task);
+                self.waiting = false;
+            }
+
+            EntityMessage::KillYourself => {
+                let _ = self
+                    .world_aid
+                    .send(WorldManagerMessage::KillMe(self.self_aid.clone()));
+                self.alive = false;
+            }
+
+            EntityMessage::Ok => {
+                //world manager godkände flyyten
+                //uppdatera EntityCore-> cunnrent_pos
+                self.core.apply_ok();
+                self.waiting = false;
+                thread::sleep(MOVE_TIME);
+            }
+
+            EntityMessage::Err => {
+                // world manager neckade flytten
+                // ingen ändring i pos
+                self.core.apply_err();
+                self.waiting = false;
+            }
+
+            EntityMessage::InventoryOk => {
+                self.waiting = false;
+            }
+
+            EntityMessage::InventoryErr => {
+                self.waiting = false;
+                //tillfälligt lösning
+            }
+        }
+    }
+
     fn run(&mut self, mailbox: Receiver<EntityMessage>) {
         loop {
-            while let Ok(msg) = mailbox.try_recv() {
-                match msg {
-                    EntityMessage::Task(task) => {
-                        self.core.new_task(task);
-                        self.waiting = false;
-                    },
-
-                    EntityMessage::KillYourself => {
-                        let _ = self
-                            .world_aid
-                            .send(WorldManagerMessage::KillMe(self.self_aid.clone()));
-                        break;
-                    }
-
-                    EntityMessage::Ok => {
-                        //world manager godkände flyyten
-                        //uppdatera EntityCore-> cunnrent_pos
-                        self.core.apply_ok();
-                        thread::sleep(Duration::from_millis(500));
-                        self.waiting = false;
-                    }
-
-                    EntityMessage::Err => {
-                        // world manager neckade flytten
-                        // ingen ändring i pos
-                        self.core.apply_err();
-                        self.waiting = false;
-                    }
-
-                    EntityMessage::InventoryOk => {
-                        self.waiting = false;
-                    }
-                    
-                    EntityMessage::InventoryErr => {
-                        self.waiting = false;
-                        //tillfälligt lösning
-                    }
+            while self.waiting {
+                if let Ok(msg) = mailbox.recv() {
+                    self.msg_handler(msg);
                 }
             }
-            if self.waiting {
-                continue;
+            while let Ok(msg) = mailbox.try_recv() {
+                self.msg_handler(msg);
             }
+
+            if !self.alive {
+                break;
+            }
+
             //process task
             if let Some(req) = self.core.process_task() {
                 match req {
@@ -251,13 +450,13 @@ impl Entity {
                         self.waiting = true;
                     }
                     Request::GiveItem(item) => {
-                        thread::sleep(Duration::from_millis(3000));
+                        thread::sleep(TRANSFER_TIME);
                         //println!("Dropped 1000 Megaforium");
                         self.core.sub_tasks.pop_front();
                         self.waiting = false;
                     }
                     Request::TakeItem(item) => {
-                        thread::sleep(Duration::from_millis(3000));
+                        thread::sleep(TRANSFER_TIME);
                         //println!("Took 1000 Megaforium");
                         self.core.sub_tasks.pop_front();
                         self.waiting = false;
@@ -327,5 +526,72 @@ mod tests {
         //core.apply_task(task);
 
         //assert_eq!(core.is_busy, true);
+    }
+
+    #[test]
+    fn dir_towards_pos_test() {
+        assert_eq!(dir_towards_pos((0, 0), (0, 0)), None);
+        assert_eq!(dir_towards_pos((1, 1), (1, 1)), None);
+        assert_eq!(dir_towards_pos((3, 5), (3, 5)), None);
+
+        assert_eq!(dir_towards_pos((0, 1), (0, 0)), Some(Dir::Up));
+        assert_eq!(dir_towards_pos((1, 0), (0, 0)), Some(Dir::Left));
+        assert_eq!(dir_towards_pos((0, 0), (0, 1)), Some(Dir::Down));
+        assert_eq!(dir_towards_pos((0, 0), (1, 0)), Some(Dir::Right));
+
+        assert_eq!(dir_towards_pos((3, 5), (2, 3)), Some(Dir::Up));
+        assert_eq!(dir_towards_pos((3, 5), (1, 6)), Some(Dir::Left));
+        assert_eq!(dir_towards_pos((3, 5), (5, 4)), Some(Dir::Right));
+        assert_eq!(dir_towards_pos((3, 5), (4, 7)), Some(Dir::Down));
+    }
+
+    #[test]
+    fn dir_angle_test() {
+        assert_eq!(dir_angle(Dir::Up, Dir::Up), 0);
+        assert_eq!(dir_angle(Dir::Up, Dir::Left), 1);
+        assert_eq!(dir_angle(Dir::Up, Dir::Down), 2);
+        assert_eq!(dir_angle(Dir::Up, Dir::Right), 3);
+
+        assert_eq!(dir_angle(Dir::Left, Dir::Up), 3);
+        assert_eq!(dir_angle(Dir::Left, Dir::Left), 0);
+        assert_eq!(dir_angle(Dir::Left, Dir::Down), 1);
+        assert_eq!(dir_angle(Dir::Left, Dir::Right), 2);
+
+        assert_eq!(dir_angle(Dir::Down, Dir::Up), 2);
+        assert_eq!(dir_angle(Dir::Down, Dir::Left), 3);
+        assert_eq!(dir_angle(Dir::Down, Dir::Down), 0);
+        assert_eq!(dir_angle(Dir::Down, Dir::Right), 1);
+
+        assert_eq!(dir_angle(Dir::Right, Dir::Up), 1);
+        assert_eq!(dir_angle(Dir::Right, Dir::Left), 2);
+        assert_eq!(dir_angle(Dir::Right, Dir::Down), 3);
+        assert_eq!(dir_angle(Dir::Right, Dir::Right), 0);
+    }
+
+    #[test]
+    fn rotate_dir_test() {
+        assert_eq!(rotate_dir(Dir::Up, 0), Dir::Up);
+        assert_eq!(rotate_dir(Dir::Up, 1), Dir::Left);
+        assert_eq!(rotate_dir(Dir::Up, 2), Dir::Down);
+        assert_eq!(rotate_dir(Dir::Up, 3), Dir::Right);
+        assert_eq!(rotate_dir(Dir::Up, 4), Dir::Up);
+
+        assert_eq!(rotate_dir(Dir::Left, 0), Dir::Left);
+        assert_eq!(rotate_dir(Dir::Left, 1), Dir::Down);
+        assert_eq!(rotate_dir(Dir::Left, 2), Dir::Right);
+        assert_eq!(rotate_dir(Dir::Left, 3), Dir::Up);
+        assert_eq!(rotate_dir(Dir::Left, 4), Dir::Left);
+
+        assert_eq!(rotate_dir(Dir::Down, 0), Dir::Down);
+        assert_eq!(rotate_dir(Dir::Down, 1), Dir::Right);
+        assert_eq!(rotate_dir(Dir::Down, 2), Dir::Up);
+        assert_eq!(rotate_dir(Dir::Down, 3), Dir::Left);
+        assert_eq!(rotate_dir(Dir::Down, 4), Dir::Down);
+
+        assert_eq!(rotate_dir(Dir::Right, 0), Dir::Right);
+        assert_eq!(rotate_dir(Dir::Right, 1), Dir::Up);
+        assert_eq!(rotate_dir(Dir::Right, 2), Dir::Left);
+        assert_eq!(rotate_dir(Dir::Right, 3), Dir::Down);
+        assert_eq!(rotate_dir(Dir::Right, 4), Dir::Right);
     }
 }

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -5,7 +5,7 @@ use crate::messages::EntityMessage;
 use crate::task_manager::{Task, TaskManagerMessage};
 use crate::world_manager::{Pos, WorldManagerMessage};
 use std::cmp::{max, min};
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::mpsc::{Receiver, sync_channel};
 use std::thread;
 use std::time::Duration;
@@ -32,9 +32,7 @@ struct EntityCore {
     pending_move: Option<Pos>,
     sub_tasks: VecDeque<SubTask>,
     open_neighbors: HashSet<Pos>,
-    pathfinding_state: PathfindingState,
-    next_pathfinding_state: Option<PathfindingState>,
-    visited_states: HashSet<(Pos, PathfindingState)>,
+    heuristic: HashMap<Pos, usize>,
 }
 
 enum SubTask {
@@ -50,84 +48,21 @@ enum Request {
     TakeItem(Item),
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-enum Dir {
-    Up,
-    Right,
-    Down,
-    Left,
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
-enum PathfindingState {
-    ProductivePath,
-    HandRule(usize, Dir),
-}
-
-const DEFAULT_PATHFINDING_STATE: PathfindingState = PathfindingState::ProductivePath;
-
 fn abs_sub(a: usize, b: usize) -> usize {
     return max(a, b) - min(a, b);
 }
 
-// dx + dy
+// |x2 - x1| + |y2 - y1|
+#[allow(unused)]
 fn manhattan_distance(from: Pos, to: Pos) -> usize {
     return abs_sub(from.0, to.0) + abs_sub(from.1, to.1);
 }
 
-// approximate the direction between to points
-fn dir_towards_pos(from: Pos, to: Pos) -> Option<Dir> {
-    return if abs_sub(from.0, to.0) >= abs_sub(from.1, to.1) {
-        if from.0 < to.0 {
-            Some(Dir::Right)
-        } else if from.0 > to.0 {
-            Some(Dir::Left)
-        } else {
-            None
-        }
-    } else {
-        if from.1 < to.1 {
-            Some(Dir::Down)
-        } else if from.1 > to.1 {
-            Some(Dir::Up)
-        } else {
-            None
-        }
-    };
-}
-
-// The counter clockwise angle between two directions in quarter turns
-fn dir_angle(from: Dir, to: Dir) -> usize {
-    let from = match from {
-        Dir::Up => 0,
-        Dir::Left => 1,
-        Dir::Down => 2,
-        Dir::Right => 3,
-    };
-    let to = match to {
-        Dir::Up => 0,
-        Dir::Left => 1,
-        Dir::Down => 2,
-        Dir::Right => 3,
-    };
-    return (4 + to - from) % 4;
-}
-
-// Rotate direction counter clockwise by angle in quarter turns
-fn rotate_dir(dir: Dir, angle: usize) -> Dir {
-    let dir = match dir {
-        Dir::Up => 0,
-        Dir::Left => 1,
-        Dir::Down => 2,
-        Dir::Right => 3,
-    };
-    match (dir + angle) % 4 {
-        0 => Dir::Up,
-        1 => Dir::Left,
-        2 => Dir::Down,
-        3 => Dir::Right,
-        _ => unreachable!(),
-    }
+// (x2 - x1)^2 + (y2 - y1)^2
+fn euclidean_distance_squared(from: Pos, to: Pos) -> usize {
+    let dx = abs_sub(from.0, to.0);
+    let dy = abs_sub(from.1, to.1);
+    return dx * dx + dy * dy;
 }
 
 // Returns a set of all adjacent positions
@@ -153,80 +88,56 @@ impl EntityCore {
             pending_move: None,
             sub_tasks: VecDeque::new(),
             open_neighbors: neighbors(start_pos),
-            pathfinding_state: DEFAULT_PATHFINDING_STATE,
-            next_pathfinding_state: None,
-            visited_states: HashSet::new(),
+            heuristic: HashMap::new(),
         }
     }
 
-    fn pathfind(&mut self, dst: Pos) -> Option<(Pos, PathfindingState)> {
-        // algorithm from https://en.wikipedia.org/wiki/Maze-solving_algorithm#Maze-routing_algorithm
+    fn pathfind(&mut self, dst: Pos) -> Option<Pos> {
+        // RTA* algorithm
 
-        let cur = self.current_pos;
-        let md_cur = manhattan_distance(cur, dst);
-
-        if cur == dst {
+        if self.current_pos == dst {
             return None;
         }
 
-        // preferred_dir is direction towards dst if in ProductivePath state
-        // or to the right of facing_dir if in HandRule state
-        let (md_best, preferred_dir) = match self.pathfinding_state {
-            // unwrap will never panic since cur != dst
-            PathfindingState::ProductivePath => (md_cur, dir_towards_pos(cur, dst).unwrap()),
-            PathfindingState::HandRule(md_best, facing_dir) => (md_best, rotate_dir(facing_dir, 3)),
-        };
+        let mut best: Option<(Pos, usize)> = None;
+        let mut second: Option<(Pos, usize)> = None;
 
-        let mut path: Option<Pos> = None;
+        for &s in self.open_neighbors.iter() {
+            // In my experience, using a euclidean distance heuristic
+            // produces better looking paths, even on discrete grids
+            // but this could be changed to manhattan distance as well.
+            let default = euclidean_distance_squared(s, dst);
+            let h_s = *self.heuristic.get(&s).unwrap_or(&default);
+            // all neighbors are a distance 1 away
+            let f_s = h_s.checked_add(1).unwrap_or(h_s);
 
-        // try taking productive path if at closest distance
-        if md_cur <= md_best {
-            for neighbor in self.open_neighbors.iter() {
-                if manhattan_distance(*neighbor, dst) < md_cur
-                    && (path.is_none()
-                        // prioritize moving in the dimension with largest difference
-                        || dir_towards_pos(cur, *neighbor) == dir_towards_pos(cur, dst))
-                {
-                    path = Some(*neighbor);
-                }
+            // find best and second-best neighbor
+            if best.is_none_or(|(_, f)| f > f_s) {
+                second = best;
+                best = Some((s, f_s));
+            } else if second.is_none_or(|(_, f)| f > f_s) {
+                second = Some((s, f_s));
             }
         }
 
-        if let Some(path_pos) = path {
-            // productive path found, enter ProductivePath state
-            return Some((path_pos, PathfindingState::ProductivePath));
-        }
-        // no productive path exists
-
-        // (next pos, dir to next pos, angle between preferred_dir and dir to next pos)
-        let mut path: Option<(Pos, Dir, usize)> = None;
-
-        for neighbor in self.open_neighbors.iter() {
-            // get direction to neighbor and its angle to preferred_dir
-            // unwrap will never panic since cur != *nieghbor
-            let neighbor_dir = dir_towards_pos(cur, *neighbor).unwrap();
-            let neighbor_angle = dir_angle(preferred_dir, neighbor_dir);
-            if let Some((_, _, path_angle)) = path {
-                // Take the first path ccw of preferred_dir (including preferred_dir itself)
-                if neighbor_angle < path_angle {
-                    path = Some((*neighbor, neighbor_dir, neighbor_angle));
-                }
-            } else {
-                // If no other path found yet, take this one
-                path = Some((*neighbor, neighbor_dir, neighbor_angle));
-            }
+        // second best defaults to infinity
+        let f_new = second.map(|(_, f)| f).unwrap_or(usize::MAX);
+        // update current heuristic to and second best neighbor
+        // The intuition is that revisiting this node is only as
+        // good as taking the second best path since the best path
+        // will have already been expored and not worked out.
+        // It should also not decrease since visiting it again
+        // shouldn't make it better.
+        if self
+            .heuristic
+            .get(&self.current_pos)
+            .is_none_or(|&f| f < f_new)
+        {
+            self.heuristic.insert(self.current_pos, f_new);
         }
 
-        if let Some((path_pos, path_dir, _)) = path {
-            // no productive path found, enter HandRule state
-            return Some((
-                path_pos,
-                PathfindingState::HandRule(min(md_cur, md_best), path_dir),
-            ));
-        } else {
-            // completely stuck
-            return None;
-        }
+        // try to take best path
+        return best.map(|(pos, _)| pos);
     }
 
     fn process_task(&mut self) -> Option<Request> {
@@ -235,12 +146,12 @@ impl EntityCore {
                 SubTask::Move(pos) => {
                     if *pos == self.current_pos {
                         self.sub_tasks.pop_front();
+                        self.heuristic.clear();
                         return None;
                     }
 
-                    if let Some((target, state)) = self.pathfind(*pos) {
+                    if let Some(target) = self.pathfind(*pos) {
                         self.pending_move = Some(target);
-                        self.next_pathfinding_state = Some(state);
                         return Some(Request::Move(target));
                     } else {
                         // completely stuck
@@ -303,17 +214,6 @@ impl EntityCore {
             self.current_pos = pos;
             // recalculate neighbors
             self.open_neighbors = neighbors(pos);
-
-            // move successful, update state
-            if let Some(state) = self.next_pathfinding_state.take() {
-                // since walls can move, the algorithm can get stuck in a loop, if that happens, restart the algorithm by clearing its memory
-                if !self.visited_states.insert((pos, state)) {
-                    self.visited_states.clear();
-                    self.pathfinding_state = DEFAULT_PATHFINDING_STATE;
-                } else {
-                    self.pathfinding_state = state;
-                }
-            }
         }
     }
     /// Anropas när WorldManager nekar en flytt.
@@ -323,9 +223,6 @@ impl EntityCore {
             // pos is not open
             self.open_neighbors.remove(&pos);
         }
-
-        // move unsuccessful, next state is invalid
-        self.next_pathfinding_state = None;
     }
 }
 
@@ -526,72 +423,5 @@ mod tests {
         //core.apply_task(task);
 
         //assert_eq!(core.is_busy, true);
-    }
-
-    #[test]
-    fn dir_towards_pos_test() {
-        assert_eq!(dir_towards_pos((0, 0), (0, 0)), None);
-        assert_eq!(dir_towards_pos((1, 1), (1, 1)), None);
-        assert_eq!(dir_towards_pos((3, 5), (3, 5)), None);
-
-        assert_eq!(dir_towards_pos((0, 1), (0, 0)), Some(Dir::Up));
-        assert_eq!(dir_towards_pos((1, 0), (0, 0)), Some(Dir::Left));
-        assert_eq!(dir_towards_pos((0, 0), (0, 1)), Some(Dir::Down));
-        assert_eq!(dir_towards_pos((0, 0), (1, 0)), Some(Dir::Right));
-
-        assert_eq!(dir_towards_pos((3, 5), (2, 3)), Some(Dir::Up));
-        assert_eq!(dir_towards_pos((3, 5), (1, 6)), Some(Dir::Left));
-        assert_eq!(dir_towards_pos((3, 5), (5, 4)), Some(Dir::Right));
-        assert_eq!(dir_towards_pos((3, 5), (4, 7)), Some(Dir::Down));
-    }
-
-    #[test]
-    fn dir_angle_test() {
-        assert_eq!(dir_angle(Dir::Up, Dir::Up), 0);
-        assert_eq!(dir_angle(Dir::Up, Dir::Left), 1);
-        assert_eq!(dir_angle(Dir::Up, Dir::Down), 2);
-        assert_eq!(dir_angle(Dir::Up, Dir::Right), 3);
-
-        assert_eq!(dir_angle(Dir::Left, Dir::Up), 3);
-        assert_eq!(dir_angle(Dir::Left, Dir::Left), 0);
-        assert_eq!(dir_angle(Dir::Left, Dir::Down), 1);
-        assert_eq!(dir_angle(Dir::Left, Dir::Right), 2);
-
-        assert_eq!(dir_angle(Dir::Down, Dir::Up), 2);
-        assert_eq!(dir_angle(Dir::Down, Dir::Left), 3);
-        assert_eq!(dir_angle(Dir::Down, Dir::Down), 0);
-        assert_eq!(dir_angle(Dir::Down, Dir::Right), 1);
-
-        assert_eq!(dir_angle(Dir::Right, Dir::Up), 1);
-        assert_eq!(dir_angle(Dir::Right, Dir::Left), 2);
-        assert_eq!(dir_angle(Dir::Right, Dir::Down), 3);
-        assert_eq!(dir_angle(Dir::Right, Dir::Right), 0);
-    }
-
-    #[test]
-    fn rotate_dir_test() {
-        assert_eq!(rotate_dir(Dir::Up, 0), Dir::Up);
-        assert_eq!(rotate_dir(Dir::Up, 1), Dir::Left);
-        assert_eq!(rotate_dir(Dir::Up, 2), Dir::Down);
-        assert_eq!(rotate_dir(Dir::Up, 3), Dir::Right);
-        assert_eq!(rotate_dir(Dir::Up, 4), Dir::Up);
-
-        assert_eq!(rotate_dir(Dir::Left, 0), Dir::Left);
-        assert_eq!(rotate_dir(Dir::Left, 1), Dir::Down);
-        assert_eq!(rotate_dir(Dir::Left, 2), Dir::Right);
-        assert_eq!(rotate_dir(Dir::Left, 3), Dir::Up);
-        assert_eq!(rotate_dir(Dir::Left, 4), Dir::Left);
-
-        assert_eq!(rotate_dir(Dir::Down, 0), Dir::Down);
-        assert_eq!(rotate_dir(Dir::Down, 1), Dir::Right);
-        assert_eq!(rotate_dir(Dir::Down, 2), Dir::Up);
-        assert_eq!(rotate_dir(Dir::Down, 3), Dir::Left);
-        assert_eq!(rotate_dir(Dir::Down, 4), Dir::Down);
-
-        assert_eq!(rotate_dir(Dir::Right, 0), Dir::Right);
-        assert_eq!(rotate_dir(Dir::Right, 1), Dir::Up);
-        assert_eq!(rotate_dir(Dir::Right, 2), Dir::Left);
-        assert_eq!(rotate_dir(Dir::Right, 3), Dir::Down);
-        assert_eq!(rotate_dir(Dir::Right, 4), Dir::Right);
     }
 }

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -43,13 +43,6 @@ enum SubTask {
     Done,
 }
 
-enum Request {
-    Move(Pos),
-    RequestTask,
-    GiveItem(Item),
-    TakeItem(Item),
-}
-
 fn manhattan_distance(from: Pos, to: Pos) -> usize {
     return from.0.abs_diff(to.0) + from.1.abs_diff(to.1);
 }

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -251,13 +251,13 @@ impl Entity {
                         self.waiting = true;
                     }
                     Request::GiveItem(item) => {
-                        thread::sleep(Duration::from_millis(500));
+                        thread::sleep(Duration::from_millis(3000));
                         //println!("Dropped 1000 Megaforium");
                         self.core.sub_tasks.pop_front();
                         self.waiting = false;
                     }
                     Request::TakeItem(item) => {
-                        thread::sleep(Duration::from_millis(500));
+                        thread::sleep(Duration::from_millis(3000));
                         //println!("Took 1000 Megaforium");
                         self.core.sub_tasks.pop_front();
                         self.waiting = false;
@@ -283,8 +283,8 @@ mod tests {
         let new_pos = (10, 10);
         let task = Task::MoveTo(new_pos);
 
-        assert_eq!(core.apply_task(task), Some(new_pos));
-        assert_eq!(core.pending_move, Some(new_pos));
+        //assert_eq!(core.apply_task(task), Some(new_pos));
+        //assert_eq!(core.pending_move, Some(new_pos));
     }
 
     #[test]
@@ -294,7 +294,7 @@ mod tests {
 
         let new_pos = (20, 20);
         let task = Task::MoveTo(new_pos);
-        core.apply_task(task);
+        //core.apply_task(task);
         core.apply_ok();
         assert_eq!(core.current_pos, new_pos);
     }
@@ -308,7 +308,7 @@ mod tests {
 
         let task = Task::MoveTo(new_pos);
 
-        core.apply_task(task);
+        //core.apply_task(task);
         core.apply_err();
 
         assert_eq!(core.current_pos, start_pos);
@@ -320,12 +320,12 @@ mod tests {
     fn is_bussy() {
         let start_pos = (10, 10);
         let mut core = EntityCore::new(start_pos);
-        assert_eq!(core.is_busy, false);
+        //assert_eq!(core.is_busy, false);
 
         let new_pos = (20, 20);
         let task = Task::MoveTo(new_pos);
-        core.apply_task(task);
+        //core.apply_task(task);
 
-        assert_eq!(core.is_busy, true);
+        //assert_eq!(core.is_busy, true);
     }
 }

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -1,8 +1,13 @@
 use crate::aid::AID;
-use crate::inventory::{InventoryMessage,self};
-use crate::messages::{EntityMessage, Task, TaskManagerMessage};
+use crate::inventory::{self, InventoryMessage};
+use crate::item::Item;
+use crate::messages::EntityMessage;
+use crate::task_manager::{Task, TaskManagerMessage};
 use crate::world_manager::{Pos, WorldManagerMessage};
+use std::collections::VecDeque;
 use std::sync::mpsc::Receiver;
+use std::thread;
+use std::time::Duration;
 
 /// Ren logik- och state för en entity.
 ///
@@ -12,13 +17,26 @@ use std::sync::mpsc::Receiver;
 /// - att behandla inkommande tasks
 /// - att uppdatera state baserat på Ok/Err från WorldManager
 ///
-/// Innehåller ingen actor‑logik. 
+/// Innehåller ingen actor‑logik.
 /// Används av `Entity` som den faktiska logikdelen.
 #[allow(dead_code)]
 struct EntityCore {
     current_pos: Pos,
     pending_move: Option<Pos>,
-    is_busy: bool,
+    sub_tasks: VecDeque<SubTask>,
+}
+
+enum SubTask {
+    Move(Pos),
+    TakeItem(Item),
+    GiveItem(Item),
+}
+
+enum Request {
+    Move(Pos),
+    RequestTask,
+    GiveItem(Item),
+    TakeItem(Item),
 }
 
 #[allow(dead_code)]
@@ -28,42 +46,86 @@ impl EntityCore {
         EntityCore {
             current_pos: start_pos,
             pending_move: None,
-            is_busy: false,
+            sub_tasks: VecDeque::new(),
         }
+    }
+
+    fn process_move(&mut self, pos: Pos) -> Option<Pos> {
+        let mut return_pos: Option<Pos> = None;
+
+        if pos.0 > self.current_pos.0 {
+            return_pos = Some((self.current_pos.0 + 1, self.current_pos.1));
+        } else if pos.0 < self.current_pos.0 {
+            return_pos = Some((self.current_pos.0 - 1, self.current_pos.1));
+        } else if pos.1 > self.current_pos.1 {
+            return_pos = Some((self.current_pos.0, self.current_pos.1 + 1));
+        } else if pos.1 < self.current_pos.1 {
+            return_pos = Some((self.current_pos.0, self.current_pos.1 - 1));
+        } else {
+            self.sub_tasks.pop_front();
+        }
+        self.pending_move = return_pos;
+        return return_pos;
+    }
+
+    fn process_task(&mut self) -> Option<Request> {
+        if self.sub_tasks.is_empty() {
+            return Some(Request::RequestTask);
+        }
+        if let Some(sub_task) = self.sub_tasks.front() {
+            match sub_task {
+                SubTask::Move(pos) => {
+                    if let Some(target) = self.process_move(*pos) {
+                        return Some(Request::Move(target));
+                    } else {
+                        //
+                        return None;
+                    }
+                }
+                SubTask::GiveItem(item) => {
+                    return Some(Request::GiveItem(*item));
+                }
+                SubTask::TakeItem(item) => {
+                    return Some(Request::TakeItem(*item));
+                }
+            }
+        }
+        return None;
     }
 
     /// Behandlar en Task och returnerar eventuell Move-position
     /// som Entity-aktorn ska skicka till WorldManager.
-    fn apply_task(&mut self, task: Task) -> Option<Pos> {
+    fn new_task(&mut self, task: Task) {   
         match task {
             Task::MoveTo(pos) => {
-                self.pending_move = Some(pos);
-                self.is_busy = true;
-                Some(pos)
+                self.sub_tasks.push_back(SubTask::Move(pos));
             }
-
-            Task::AddItem { .. } => {
-                self.is_busy = true;
-                None
-            }
-            Task::RemoveItem { .. } => {
-                self.is_busy = true;
-                None
-            }
-            Task::TakeFrom { .. } => {
-                self.is_busy = true;
-                None
-            }
-            Task::GiveTo { .. } => {
-                self.is_busy = true;
-                None
-            }
-            Task::PrintInventory(_) => {
-                self.is_busy = true;
-                None
-            }
-
-            Task::Idle => None,
+            Task::DeliverItem(item,from, to) => {
+                self.sub_tasks.push_back(SubTask::Move(from));
+                self.sub_tasks.push_back(SubTask::TakeItem(item));
+                self.sub_tasks.push_back(SubTask::Move(to));
+                self.sub_tasks.push_back(SubTask::GiveItem(item));
+            },
+            _ => (),
+            // Task::AddItem { .. } => {
+            //     self.is_busy = true;
+            //     None
+            // }
+            // Task::RemoveItem { .. } => {
+            //     self.is_busy = true;
+            //     None
+            // }
+            // Task::TakeFrom { .. } => {
+            //     self.is_busy = true;
+            //     None
+            // }
+            // Task::GiveTo { .. } => {
+            //     self.is_busy = true;
+            //     None
+            // }
+            // Task::PrintInventory(_) => {
+            //     self.is_busy = true;
+            //     None
         }
     }
     /// Anropas när WorldManager godkänner en flytt.
@@ -71,7 +133,7 @@ impl EntityCore {
     fn apply_ok(&mut self) {
         if let Some(pos) = self.pending_move.take() {
             self.current_pos = pos;
-            self.is_busy = false;
+            self.pending_move = None;
         }
     }
     /// Anropas när WorldManager nekar en flytt.
@@ -93,6 +155,7 @@ impl EntityCore {
 /// Entity själv hanterar endast actor‑beteende och message‑flow.
 pub struct Entity {
     core: EntityCore,
+    waiting: bool,
     world_aid: AID<WorldManagerMessage>,
     task_aid: AID<TaskManagerMessage>,
     inventory: AID<InventoryMessage>,
@@ -120,6 +183,7 @@ impl Entity {
     ) -> Self {
         Entity {
             core: EntityCore::new(start_pos),
+            waiting: false,
             world_aid: world,
             task_aid: task,
             inventory: inventory::init(),
@@ -128,79 +192,76 @@ impl Entity {
     }
 
     fn run(&mut self, mailbox: Receiver<EntityMessage>) {
-        for msg in mailbox {
-            match msg {
-                EntityMessage::Task(task) => match task {
-                    Task::MoveTo(_pos) => {
-                        if let Some(pos) = self.core.apply_task(task) {
-                            let _ = self
-                                .world_aid
-                                .send(WorldManagerMessage::Move(pos, self.self_aid.clone()));
-                        }
-                    }
+        loop {
+            while let Ok(msg) = mailbox.try_recv() {
+                match msg {
+                    EntityMessage::Task(task) => {
+                        self.core.new_task(task);
+                        self.waiting = false;
+                    },
 
-                    Task::AddItem { item, amount } => {
-                        let _ = self.inventory.send(InventoryMessage::Add(self.self_aid.clone(), (item,amount)));
-                    }
-
-                    Task::RemoveItem { item, amount } => {
+                    EntityMessage::KillYourself => {
                         let _ = self
-                            .inventory
-                            .send(InventoryMessage::Remove(self.self_aid.clone(), (item,amount)));
+                            .world_aid
+                            .send(WorldManagerMessage::KillMe(self.self_aid.clone()));
+                        break;
                     }
 
-                    Task::TakeFrom { from, item, amount } => {
+                    EntityMessage::Ok => {
+                        //world manager godkände flyyten
+                        //uppdatera EntityCore-> cunnrent_pos
+                        self.core.apply_ok();
+                        thread::sleep(Duration::from_millis(500));
+                        self.waiting = false;
+                    }
+
+                    EntityMessage::Err => {
+                        // world manager neckade flytten
+                        // ingen ändring i pos
+                        self.core.apply_err();
+                        self.waiting = false;
+                    }
+
+                    EntityMessage::InventoryOk => {
+                        self.waiting = false;
+                    }
+                    
+                    EntityMessage::InventoryErr => {
+                        self.waiting = false;
+                        //tillfälligt lösning
+                    }
+                }
+            }
+            if self.waiting {
+                continue;
+            }
+            //process task
+            if let Some(req) = self.core.process_task() {
+                match req {
+                    Request::Move(pos) => {
                         let _ = self
-                            .inventory
-                            .send(InventoryMessage::TakeFrom(self.self_aid.clone(), self.inventory.clone(), (item,amount)));
+                            .world_aid
+                            .send(WorldManagerMessage::Move(pos, self.self_aid.clone()));
+                        self.waiting = true;
                     }
-
-                    Task::GiveTo { to, item, amount } => {
+                    Request::RequestTask => {
                         let _ = self
-                            .inventory
-                            .send(InventoryMessage::GiveTo(self.self_aid.clone(), self.inventory.clone(),(item,amount)));
+                            .task_aid
+                            .send(TaskManagerMessage::GiveMeNewTask(self.self_aid.clone()));
+                        self.waiting = true;
                     }
-
-                    Task::PrintInventory(name) => {
-                        let _ = self.inventory.send(InventoryMessage::PrintInventory(name));
+                    Request::GiveItem(item) => {
+                        thread::sleep(Duration::from_millis(500));
+                        //println!("Dropped 1000 Megaforium");
+                        self.core.sub_tasks.pop_front();
+                        self.waiting = false;
                     }
-
-                    Task::Idle => {}
-                },
-
-                EntityMessage::KillYourself => {
-                    let _ = self
-                        .world_aid
-                        .send(WorldManagerMessage::KillMe(self.self_aid.clone()));
-                    break;
-                }
-
-                EntityMessage::Ok => {
-                    //world manager godkände flyyten
-                    //uppdatera EntityCore-> cunnrent_pos
-                    self.core.apply_ok();
-                    self.core.is_busy = false;
-                }
-
-                EntityMessage::Err => {
-                    // world manager neckade flytten
-                    // ingen ändring i pos
-                    self.core.apply_err();
-                    self.core.is_busy = false;
-                }
-
-                EntityMessage::InventoryOk =>{
-
-                    //tillfälligt lösning
-                    self.core.is_busy = false;
-                }
-
-
-                EntityMessage::InventoryErr =>{
-
-                    //tillfälligt lösning
-                    self.core.is_busy = false;
-
+                    Request::TakeItem(item) => {
+                        thread::sleep(Duration::from_millis(500));
+                        //println!("Took 1000 Megaforium");
+                        self.core.sub_tasks.pop_front();
+                        self.waiting = false;
+                    }
                 }
             }
         }
@@ -262,7 +323,7 @@ mod tests {
         assert_eq!(core.is_busy, false);
 
         let new_pos = (20, 20);
-        let task = messages::Task::MoveTo(new_pos);
+        let task = Task::MoveTo(new_pos);
         core.apply_task(task);
 
         assert_eq!(core.is_busy, true);

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -9,6 +9,8 @@ use std::sync::mpsc::Receiver;
 use std::thread;
 use std::time::Duration;
 
+// duration to wait while idling
+const IDLE_TIME: Duration = Duration::from_millis(500);
 // duration to wait after moving
 const MOVE_TIME: Duration = Duration::from_millis(250);
 // duration to wait after transferring items
@@ -36,7 +38,7 @@ struct EntityCore {
 
 #[derive(Clone)]
 enum SubTask {
-    MoveError,
+    Idle,
     Move(Pos),
     TakeItem(AID<EntityMessage>, Item),
     GiveItem(AID<EntityMessage>, Item),
@@ -146,7 +148,7 @@ impl EntityCore {
             } else {
                 // completely stuck
                 // wait and hope something moves out of the way
-                return SubTask::MoveError;
+                return SubTask::Idle;
             }
         }
         return sub_task.clone();
@@ -166,6 +168,9 @@ impl EntityCore {
                 self.sub_tasks.push_back(SubTask::Move(to));
                 self.sub_tasks
                     .push_back(SubTask::GiveItem(to_aid.clone(), item));
+            }
+            Task::Idle => {
+                self.sub_tasks.push_back(SubTask::Idle);
             }
             _ => (),
             // Task::AddItem { .. } => {
@@ -341,8 +346,8 @@ impl Entity {
             //process task
             let task = self.core.process_task();
             match task {
-                SubTask::MoveError => {
-                    thread::sleep(MOVE_TIME);
+                SubTask::Idle => {
+                    thread::sleep(IDLE_TIME);
                 }
                 SubTask::Move(pos) => {
                     let _ = self

--- a/src/game_manager.rs
+++ b/src/game_manager.rs
@@ -61,6 +61,7 @@ impl GameManager {
             (8, 5),
             (8, 6),
             (9, 6),
+            (7, 6),
         ] {
             let _ = self.world.send(WorldManagerMessage::PlaceObstacle(pos));
         }
@@ -86,6 +87,16 @@ impl GameManager {
             .world
             .send(WorldManagerMessage::PlaceWorker((10, 5), worker.clone()));
 
+        let worker = Entity::new(self.world.clone(), self.task.clone(), (10, 7));
+        let _ = self
+            .world
+            .send(WorldManagerMessage::PlaceWorker((10, 7), worker.clone()));
+
+        let _ = self.task.send(TaskManagerMessage::CreatePath(
+            Item::Mutexium,
+            (14, 3),
+            (3, 4),
+        ));
         let _ = self.task.send(TaskManagerMessage::CreatePath(
             Item::Mutexium,
             (14, 3),

--- a/src/game_manager.rs
+++ b/src/game_manager.rs
@@ -1,12 +1,7 @@
 use std::{thread, time::Duration};
 
 use crate::{
-    aid::AID,
-    building::Building,
-    entity::Entity,
-    messages::{PlayerManagerMessage, TaskManagerMessage},
-    player_manager,
-    world_manager::{self, WorldManagerMessage},
+    aid::AID, building::Building, entity::Entity, item::Item, messages::{EntityMessage, PlayerManagerMessage}, player_manager, task_manager::{self, Task, TaskManagerMessage}, world_manager::{self, WorldManagerMessage}
 };
 
 pub struct GameManager {
@@ -18,7 +13,9 @@ pub struct GameManager {
 impl GameManager {
     pub fn new() -> Self {
         let world = AID::new(world_manager::main);
-        let task = AID::new(|_, _| {});
+        let task = AID::new(|aid, mailbox| {
+            task_manager::main(aid, mailbox);
+        });
         let player = AID::new({
             let world = world.clone();
             move |aid, mailbox| {
@@ -46,7 +43,7 @@ impl GameManager {
         let building2 = Building::new(self.world.clone());
         let _ = self
             .world
-            .send(WorldManagerMessage::PlaceBuilding((3, 3), building.clone()));
+            .send(WorldManagerMessage::PlaceBuilding((3, 5), building.clone()));
         let _ = self.world.send(WorldManagerMessage::PlaceBuilding(
             (15, 3),
             building2.clone(),
@@ -59,25 +56,22 @@ impl GameManager {
         let _ = self
             .world
             .send(WorldManagerMessage::PlaceWorker((x, y), worker.clone()));
-
+        
+        let _ = self.task.send(TaskManagerMessage::CreatePath(Item::Mutexium, (14, 3), (3, 4)));
         loop {
-            while x < 14 {
-                thread::sleep(Duration::from_millis(250));
-                x += 1;
-                let _ = worker.send(crate::messages::EntityMessage::Task(
-                    crate::messages::Task::MoveTo((x, y)),
-                ));
-            }
-            thread::sleep(Duration::from_millis(2500));
+            // while x < 14 {
+            //     thread::sleep(Duration::from_millis(250));
+            //     x += 1;
+            //     let _ = worker.send(EntityMessage::Task(Task::MoveTo((x, y))));
+            // }
+            // thread::sleep(Duration::from_millis(2500));
 
-            while x > 4 {
-                thread::sleep(Duration::from_millis(250));
-                x -= 1;
-                let _ = worker.send(crate::messages::EntityMessage::Task(
-                    crate::messages::Task::MoveTo((x, y)),
-                ));
-            }
-            thread::sleep(Duration::from_millis(2500));
+            // while x > 4 {
+            //     thread::sleep(Duration::from_millis(250));
+            //     x -= 1;
+            //     let _ = worker.send(EntityMessage::Task(Task::MoveTo((x, y))));
+            // }
+            // thread::sleep(Duration::from_millis(2500));
         }
     }
 }

--- a/src/game_manager.rs
+++ b/src/game_manager.rs
@@ -1,7 +1,14 @@
 use std::{thread, time::Duration};
 
 use crate::{
-    aid::AID, building::Building, entity::Entity, item::Item, messages::{EntityMessage, PlayerManagerMessage}, player_manager, task_manager::{self, Task, TaskManagerMessage}, world_manager::{self, WorldManagerMessage}
+    aid::AID,
+    building::Building,
+    entity::Entity,
+    item::Item,
+    messages::{EntityMessage, PlayerManagerMessage},
+    player_manager,
+    task_manager::{self, Task, TaskManagerMessage},
+    world_manager::{self, WorldManagerMessage},
 };
 
 pub struct GameManager {
@@ -39,39 +46,55 @@ impl GameManager {
     }
 
     fn demo(&self) {
+        // place obstacles
+        for pos in [
+            (2, 3),
+            (2, 2),
+            (3, 2),
+            (4, 2),
+            (5, 2),
+            (6, 2),
+            (7, 2),
+            (8, 2),
+            (8, 3),
+            (8, 4),
+            (8, 5),
+            (8, 6),
+            (9, 6),
+        ] {
+            let _ = self.world.send(WorldManagerMessage::PlaceObstacle(pos));
+        }
+
         let building = Building::new(self.world.clone());
-        let building2 = Building::new(self.world.clone());
         let _ = self
             .world
             .send(WorldManagerMessage::PlaceBuilding((3, 5), building.clone()));
+
+        let building = Building::new(self.world.clone());
         let _ = self.world.send(WorldManagerMessage::PlaceBuilding(
             (15, 3),
-            building2.clone(),
+            building.clone(),
         ));
-
-        let mut x = 10;
-        let y = 3;
 
         let worker = Entity::new(self.world.clone(), self.task.clone(), (10, 3));
         let _ = self
             .world
-            .send(WorldManagerMessage::PlaceWorker((x, y), worker.clone()));
-        
-        let _ = self.task.send(TaskManagerMessage::CreatePath(Item::Mutexium, (14, 3), (3, 4)));
-        loop {
-            // while x < 14 {
-            //     thread::sleep(Duration::from_millis(250));
-            //     x += 1;
-            //     let _ = worker.send(EntityMessage::Task(Task::MoveTo((x, y))));
-            // }
-            // thread::sleep(Duration::from_millis(2500));
+            .send(WorldManagerMessage::PlaceWorker((10, 3), worker.clone()));
 
-            // while x > 4 {
-            //     thread::sleep(Duration::from_millis(250));
-            //     x -= 1;
-            //     let _ = worker.send(EntityMessage::Task(Task::MoveTo((x, y))));
-            // }
-            // thread::sleep(Duration::from_millis(2500));
-        }
+        let worker = Entity::new(self.world.clone(), self.task.clone(), (10, 5));
+        let _ = self
+            .world
+            .send(WorldManagerMessage::PlaceWorker((10, 5), worker.clone()));
+
+        let _ = self.task.send(TaskManagerMessage::CreatePath(
+            Item::Mutexium,
+            (14, 3),
+            (3, 4),
+        ));
+        let _ = self.task.send(TaskManagerMessage::CreatePath(
+            Item::Mutexium,
+            (14, 3),
+            (3, 4),
+        ));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod inventory;
 mod aid;
 mod entity;
 mod building;
+mod task_manager;
 mod messages;
 mod item;
 mod game_manager;

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,39 +1,7 @@
 use crate::aid::AID;
 
-use crate::inventory::InventoryMessage;
-use crate::item::Item;
-use crate::world_manager::{Pos, Tile, WorldGrid};
-
-#[derive(Clone)]
-pub enum Task {
-    MoveTo(Pos),
-
-    AddItem {
-        item: Item,
-        amount: usize,
-    },
-
-    RemoveItem {
-        item: Item,
-        amount: usize,
-    },
-
-    TakeFrom {
-        from: AID<InventoryMessage>,
-        item: Item,
-        amount: usize,
-    },
-
-    GiveTo {
-        to: AID<InventoryMessage>,
-        item: Item,
-        amount: usize,
-    },
-
-    PrintInventory(String),
-
-    Idle,
-}
+use crate::task_manager::Task;
+use crate::world_manager::{WorldGrid, Pos, Tile};
 
 #[derive(Clone)]
 pub enum EntityMessage {

--- a/src/player_manager.rs
+++ b/src/player_manager.rs
@@ -26,11 +26,19 @@ impl Camera {
         let height = HEIGHT.try_into().unwrap();
         let mut x = self.0 + dx;
         let mut y = self.1 + dy;
-        if x < 0 {x = 0;}
-        if y < 0 {y = 0;}
-        if x >= width {x = width - 1;}
-        if y >= height {y = height - 1;}
-        
+        if x < 0 {
+            x = 0;
+        }
+        if y < 0 {
+            y = 0;
+        }
+        if x >= width {
+            x = width - 1;
+        }
+        if y >= height {
+            y = height - 1;
+        }
+
         self.0 = x;
         self.1 = y;
     }
@@ -47,8 +55,11 @@ pub fn render_loop(
 ) -> Result<(), Box<dyn std::error::Error>> {
     ratatui::run(|terminal| {
         // camera starts centered on the world
-        let mut camera = Camera((WIDTH / 2).try_into().unwrap(), (HEIGHT / 2).try_into().unwrap());
-        
+        let mut camera = Camera(
+            (WIDTH / 2).try_into().unwrap(),
+            (HEIGHT / 2).try_into().unwrap(),
+        );
+
         loop {
             let _ = world.send(WorldManagerMessage::GetDisplay(aid.clone()));
 
@@ -76,10 +87,18 @@ pub fn render_loop(
                             KeyCode::Char('q') => {
                                 break Ok(());
                             }
-                            KeyCode::Char('w') => {camera.change(0, -MOVE_CAMERA);}
-                            KeyCode::Char('s') => {camera.change(0,  MOVE_CAMERA);}
-                            KeyCode::Char('a') => {camera.change(-MOVE_CAMERA, 0);}
-                            KeyCode::Char('d') => {camera.change( MOVE_CAMERA, 0);}
+                            KeyCode::Char('w') => {
+                                camera.change(0, -MOVE_CAMERA);
+                            }
+                            KeyCode::Char('s') => {
+                                camera.change(0, MOVE_CAMERA);
+                            }
+                            KeyCode::Char('a') => {
+                                camera.change(-MOVE_CAMERA, 0);
+                            }
+                            KeyCode::Char('d') => {
+                                camera.change(MOVE_CAMERA, 0);
+                            }
                             _ => {}
                         }
                     }
@@ -92,48 +111,59 @@ pub fn render_loop(
 
 fn render(frame: &mut Frame, world_array: WorldGrid, camera: Camera) {
     let world_area = frame.area().inner(Margin::new(4, 4));
-    
+
     frame.render_widget(
         Block::new().borders(Borders::ALL).title("World"),
         world_area.outer(Margin::new(1, 1)),
     );
-    
+
     let box_w = world_area.width / 2;
     let box_h = world_area.height / 2;
-    
+
     for y in 0..box_h {
         for x in 0..box_w {
             // draw a background in the "World" area
             // this is so the player can tell the difference between buildable area and surrounding borders
-            let rect = Rect::new(world_area.x + 2*x, world_area.y + 2*y, 2, 2);
+            let rect = Rect::new(world_area.x + 2 * x, world_area.y + 2 * y, 2, 2);
             let square = Paragraph::new(".").gray();
             frame.render_widget(square, rect);
         }
     }
-    
+
     for y in 0..HEIGHT {
         for x in 0..WIDTH {
             let tile = &world_array[y][x];
-            
+
             let y: i32 = y.try_into().unwrap();
             let x: i32 = x.try_into().unwrap();
-            let draw_pos = (x + (box_w/2) as i32 - camera.0, y + (box_h/2) as i32 - camera.1);
-            let rect_at_pos = if
-                0 <= draw_pos.0 && draw_pos.0 < box_w.into() &&
-                0 <= draw_pos.1 && draw_pos.1 < box_h.into()
+            let draw_pos = (
+                x + (box_w / 2) as i32 - camera.0,
+                y + (box_h / 2) as i32 - camera.1,
+            );
+            let rect_at_pos = if 0 <= draw_pos.0
+                && draw_pos.0 < box_w.into()
+                && 0 <= draw_pos.1
+                && draw_pos.1 < box_h.into()
             {
                 // tile in visible grid
-                Rect::new(world_area.x + (2*draw_pos.0 as u16), world_area.y + (2*draw_pos.1 as u16), 2, 2)
+                Rect::new(
+                    world_area.x + (2 * draw_pos.0 as u16),
+                    world_area.y + (2 * draw_pos.1 as u16),
+                    2,
+                    2,
+                )
             } else {
                 continue;
             };
-            
-            
-            
+
             match tile {
                 Tile::Empty => {
                     // overwrite background
                     let square = Paragraph::new("  \n  ");
+                    frame.render_widget(square, rect_at_pos);
+                }
+                Tile::Obstacle => {
+                    let square = Paragraph::new("██\n██").green();
                     frame.render_widget(square, rect_at_pos);
                 }
                 Tile::Worker(_aid) => {

--- a/src/task_manager.rs
+++ b/src/task_manager.rs
@@ -1,4 +1,7 @@
-use std::{sync::mpsc::Receiver};
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::mpsc::Receiver,
+};
 
 use crate::{aid::AID, messages::EntityMessage};
 
@@ -12,23 +15,57 @@ struct Path {}
 
 #[derive(Clone)]
 pub enum Task {
-    DeliverItem((Item), Pos, Pos), //Deliver Item from A to B.
-    Produce(RecipeId),             //produce recipe id
+    DeliverItem(Item, Pos, Pos), //Deliver Item from A to B.
+    Produce(RecipeId),           //produce recipe id
     Idle,
 }
 
 #[derive(Clone)]
 pub enum TaskManagerMessage {
-    GiveMeNewTask(AID<EntityMessage>, Pos), //Worker at pos A requests a new task
+    GiveMeNewTask(AID<EntityMessage>), //Worker at pos A requests a new task
     GiveTaskTo(Task, AID<EntityMessage>), //Give some entity a task (if player wants a building to produce etc)
     CreatePath(Item, Pos, Pos),           //Create a path that delivers Item from A to B
 }
 fn main(aid: AID<TaskManagerMessage>, mailbox: Receiver<TaskManagerMessage>) {
+    //Maps AID to assigned task
+    let mut task_list: HashMap<AID<EntityMessage>, Task> = HashMap::new();
+    //A queue of non-assigned tasks
+    let mut task_queue: VecDeque<Task> = VecDeque::new();
     for msg in mailbox {
         match msg {
-            TaskManagerMessage::GiveMeNewTask(x, y) => (),
-            TaskManagerMessage::GiveTaskTo(task, to) => _ = to.send(EntityMessage::Task(task)),
-            TaskManagerMessage::CreatePath(item, from, to) => (),
+            TaskManagerMessage::GiveMeNewTask(aid) => {
+                let _ = aid.send(EntityMessage::Task(assign_task(
+                    aid.clone(),
+                    &mut task_queue,
+                    &mut task_list,
+                )));
+            }
+            TaskManagerMessage::GiveTaskTo(task, to) => {
+                let _ = to.send(EntityMessage::Task(task));
+            }
+            TaskManagerMessage::CreatePath(item, from, to) => {
+                task_queue.push_back(Task::DeliverItem(item, from, to));
+            }
         }
+    }
+}
+
+
+//Gets a new tasks and updates queue and map accordingly, returns new task.
+fn assign_task(
+    aid: AID<EntityMessage>,
+    task_queue: &mut VecDeque<Task>,
+    task_list: &mut HashMap<AID<EntityMessage>, Task>,
+) -> Task {
+    //if had a task assigned previously
+    if let Some(prev_task) = task_list.get(&aid) {
+        task_queue.push_back(prev_task.clone());
+    }
+    //if there are some new task available
+    if let Some(new_task) = task_queue.pop_front() {
+        task_list.insert(aid, new_task.clone());
+        return new_task;
+    } else {
+        return Task::Idle;
     }
 }

--- a/src/task_manager.rs
+++ b/src/task_manager.rs
@@ -1,12 +1,11 @@
 use std::{
-    collections::{HashMap, VecDeque},
-    sync::mpsc::Receiver,
+    collections::{HashMap, VecDeque}, pin::Pin, sync::mpsc::Receiver
 };
 
 use crate::{aid::AID, messages::EntityMessage};
+use crate::item::Item;
 
-#[derive(Clone)]
-enum Item {}
+
 type Pos = (usize, usize);
 
 type RecipeId = usize;
@@ -15,6 +14,7 @@ struct Path {}
 
 #[derive(Clone)]
 pub enum Task {
+    MoveTo(Pos),
     DeliverItem(Item, Pos, Pos), //Deliver Item from A to B.
     Produce(RecipeId),           //produce recipe id
     Idle,
@@ -25,8 +25,9 @@ pub enum TaskManagerMessage {
     GiveMeNewTask(AID<EntityMessage>), //Worker at pos A requests a new task
     GiveTaskTo(Task, AID<EntityMessage>), //Give some entity a task (if player wants a building to produce etc)
     CreatePath(Item, Pos, Pos),           //Create a path that delivers Item from A to B
+    CreateMoveTask(Pos),
 }
-fn main(aid: AID<TaskManagerMessage>, mailbox: Receiver<TaskManagerMessage>) {
+pub fn main(aid: AID<TaskManagerMessage>, mailbox: Receiver<TaskManagerMessage>) {
     //Maps AID to assigned task
     let mut task_list: HashMap<AID<EntityMessage>, Task> = HashMap::new();
     //A queue of non-assigned tasks
@@ -46,10 +47,13 @@ fn main(aid: AID<TaskManagerMessage>, mailbox: Receiver<TaskManagerMessage>) {
             TaskManagerMessage::CreatePath(item, from, to) => {
                 task_queue.push_back(Task::DeliverItem(item, from, to));
             }
+
+            TaskManagerMessage::CreateMoveTask(to) => {
+                task_queue.push_back(Task::MoveTo(to));
+            }
         }
     }
 }
-
 
 //Gets a new tasks and updates queue and map accordingly, returns new task.
 fn assign_task(
@@ -57,8 +61,11 @@ fn assign_task(
     task_queue: &mut VecDeque<Task>,
     task_list: &mut HashMap<AID<EntityMessage>, Task>,
 ) -> Task {
+    
     //if had a task assigned previously
     if let Some(prev_task) = task_list.get(&aid) {
+        if let Task::MoveTo(pos) = prev_task {
+        }
         task_queue.push_back(prev_task.clone());
     }
     //if there are some new task available

--- a/src/task_manager.rs
+++ b/src/task_manager.rs
@@ -1,0 +1,34 @@
+use std::{sync::mpsc::Receiver};
+
+use crate::{aid::AID, messages::EntityMessage};
+
+#[derive(Clone)]
+enum Item {}
+type Pos = (usize, usize);
+
+type RecipeId = usize;
+
+struct Path {}
+
+#[derive(Clone)]
+pub enum Task {
+    DeliverItem((Item), Pos, Pos), //Deliver Item from A to B.
+    Produce(RecipeId),             //produce recipe id
+    Idle,
+}
+
+#[derive(Clone)]
+pub enum TaskManagerMessage {
+    GiveMeNewTask(AID<EntityMessage>, Pos), //Worker at pos A requests a new task
+    GiveTaskTo(Task, AID<EntityMessage>), //Give some entity a task (if player wants a building to produce etc)
+    CreatePath(Item, Pos, Pos),           //Create a path that delivers Item from A to B
+}
+fn main(aid: AID<TaskManagerMessage>, mailbox: Receiver<TaskManagerMessage>) {
+    for msg in mailbox {
+        match msg {
+            TaskManagerMessage::GiveMeNewTask(x, y) => (),
+            TaskManagerMessage::GiveTaskTo(task, to) => _ = to.send(EntityMessage::Task(task)),
+            TaskManagerMessage::CreatePath(item, from, to) => (),
+        }
+    }
+}

--- a/src/world_manager.rs
+++ b/src/world_manager.rs
@@ -14,6 +14,7 @@ pub type Pos = (usize, usize);
 pub enum WorldManagerMessage {
     Stop, // is only necessary if there are circular AIDs (which there probably will be)
     Move(Pos, AID<EntityMessage>),
+    PlaceObstacle(Pos),
     PlaceWorker(Pos, AID<EntityMessage>),
     PlaceBuilding(Pos, AID<EntityMessage>),
     KillMe(AID<EntityMessage>),
@@ -24,6 +25,7 @@ pub enum WorldManagerMessage {
 #[derive(Clone)]
 pub enum Tile {
     Empty,
+    Obstacle,
     Worker(AID<EntityMessage>),
     Building(AID<EntityMessage>),
 }
@@ -35,7 +37,18 @@ fn get_tile(grid: &mut WorldGrid, pos: Pos) -> Option<&mut Tile> {
     return grid.get_mut(pos.1)?.get_mut(pos.0);
 }
 
-fn place_tile(
+fn place_tile(grid: &mut WorldGrid, pos: Pos, tile: Tile) {
+    // check if pos in bounds
+    if let Some(dest) = get_tile(grid, pos) {
+        // check if pos empty
+        if let Tile::Empty = *dest {
+            *dest = tile;
+            return;
+        }
+    }
+}
+
+fn place_entity(
     grid: &mut WorldGrid,
     entity_lookup: &mut WorldLookup,
     pos: Pos,
@@ -98,14 +111,15 @@ pub fn main(_this: AID<WorldManagerMessage>, mailbox: Receiver<WorldManagerMessa
             WorldManagerMessage::Move(pos, aid) => {
                 move_tile(&mut grid, &mut entity_lookup, pos, aid)
             }
-            WorldManagerMessage::PlaceWorker(pos, aid) => place_tile(
+            WorldManagerMessage::PlaceObstacle(pos) => place_tile(&mut grid, pos, Tile::Obstacle),
+            WorldManagerMessage::PlaceWorker(pos, aid) => place_entity(
                 &mut grid,
                 &mut entity_lookup,
                 pos,
                 aid.clone(),
                 Tile::Worker(aid),
             ),
-            WorldManagerMessage::PlaceBuilding(pos, aid) => place_tile(
+            WorldManagerMessage::PlaceBuilding(pos, aid) => place_entity(
                 &mut grid,
                 &mut entity_lookup,
                 pos,


### PR DESCRIPTION
**Added pathfinding algorithm to workers**

resolves #44 

I first implemented the Maze Routing Algorithm that we had discussed but it could get into infinite loops when the environment changes during its runtime. I changed it to RTA* which is simpler and should work with a dynamic environment but that can look a bit stupid and get stuck temporarily when forced to backtrack.

**Added obstacles**

Added a obstacle tile and a made a small obstacle course to test the pathfinding. I made the obstacles filled in green, like some kind of hedge maze, but this can of course be changed or removed.

**Fixed bug where workers could busy wait in certain scenarios**

resolves #48 

I also made the workers sleep when idle to further avoid busy waiting.