### PR TITLE
Animation and Background

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +152,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -365,6 +385,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +439,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -404,6 +449,7 @@ name = "gig4"
 version = "0.1.0"
 dependencies = [
  "crossterm",
+ "rand 0.10.1",
  "ratatui",
 ]
 
@@ -508,10 +554,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -547,9 +595,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "line-clipping"
@@ -811,7 +859,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -835,6 +883,12 @@ checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"
@@ -890,11 +944,22 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -902,6 +967,12 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ratatui"
@@ -1122,7 +1193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -1159,9 +1230,15 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -1350,9 +1427,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -1403,9 +1480,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "atomic",
  "getrandom 0.4.2",
@@ -1436,11 +1513,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -1449,14 +1526,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1467,9 +1544,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1477,9 +1554,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1490,9 +1567,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -1648,6 +1725,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2024"
 
 [dependencies]
 crossterm = "0.29.0"
+rand = { version = "0.10.1", features = ["chacha"] }
 ratatui = "0.30.0"

--- a/src/player_manager.rs
+++ b/src/player_manager.rs
@@ -1,10 +1,11 @@
 use std::sync::mpsc::Receiver;
 use std::time::Duration;
+use rand::{rngs::ChaCha8Rng, RngExt, SeedableRng};
 
 use crate::{
     aid::AID,
     messages::PlayerManagerMessage,
-    world_manager::{HEIGHT, Tile, WIDTH, WorldGrid, WorldManagerMessage},
+    world_manager::{HEIGHT, Tile, WIDTH, RawWorldArray, WorldGrid, WorldManagerMessage},
 };
 use crossterm::event::{Event, KeyCode, KeyEventKind, poll, read};
 use ratatui::Frame;
@@ -15,7 +16,7 @@ use ratatui::widgets::{Block, Borders, Paragraph};
 
 // Width and height of a tile on the screen in characters
 // Needs to be u16 for ratatui
-const TILE_SIZE: (u16, u16) = (2, 3);
+const TILE_SIZE: (u16, u16) = (3, 2);
 
 #[derive(Copy, Clone)]
 struct Camera(i32, i32);
@@ -49,6 +50,15 @@ impl Camera {
 // The default setting looks weird now, but it will make sense when the world is more populated.
 const MOVE_CAMERA: i32 = 1;
 
+// We do this for two reasons:
+// 1. To have 2 copies of the world for comparing
+// 2. To not lock the whole world while rendering
+fn get_copy_of_world(world_array: &WorldGrid) -> RawWorldArray {
+    let world = &world_array.lock().unwrap();
+    let copy = world.to_vec();
+    return copy;
+}
+
 pub fn render_loop(
     aid: AID<PlayerManagerMessage>,
     mailbox: Receiver<PlayerManagerMessage>,
@@ -63,9 +73,7 @@ pub fn render_loop(
         );
 
         
-        let mut world_array: WorldGrid =
-                std::array::from_fn(|_| std::array::from_fn(|_| Tile::Empty));
-        let mut old_world_array = world_array.clone();
+        let mut old_world = get_copy_of_world(&world_array);
         
         loop {
             //read all messages in mailbox
@@ -76,9 +84,12 @@ pub fn render_loop(
                 }
             }
 
-            terminal.draw(|frame| render(frame, &old_world_array, &world_array, camera))?;
+            let new_world = get_copy_of_world(&world_array);
+            terminal.draw(|frame| render(frame, &old_world, &new_world, camera))?;
+            old_world = new_world;
 
-            if poll(Duration::from_millis(30))? {
+            // 50 ms looks better with animations
+            if poll(Duration::from_millis(50))? {
                 match read()? {
                     Event::Key(key_event) if key_event.kind == KeyEventKind::Press => {
                         match key_event.code {
@@ -123,67 +134,137 @@ fn is_same_tile(old_tile: &Tile, new_tile: &Tile) -> bool {
     }
 }
 
-fn render(frame: &mut Frame, old_world_array: &WorldGrid, world_array: &WorldGrid, camera: Camera) {
-    let world_area = frame.area().inner(Margin::new(4, 4));
-    
-    frame.render_widget(
-        Block::new().borders(Borders::ALL).title("World"),
-        world_area.outer(Margin::new(1, 1)),
-    );
+fn render(frame: &mut Frame, old_world_array: &RawWorldArray, world_array: &RawWorldArray, camera: Camera) {
+    let world_area = frame.area();
 
     let box_w = world_area.width / TILE_SIZE.0;
     let box_h = world_area.height / TILE_SIZE.1;
+    
+    // this is repeated several times, so it's a closure here
+    let get_rect_from_world_xy = |x: i32, y: i32| {
+        // divide by 2 to get center of screen
+        let draw_pos = (
+            x + (box_w / 2) as i32 - camera.0,
+            y + (box_h / 2) as i32 - camera.1,
+        );
+        return if
+            0 <= draw_pos.0 && draw_pos.0 < box_w.into() &&
+            0 <= draw_pos.1 && draw_pos.1 < box_h.into()
+        {
+            // tile in visible area
+            let rx: i32 = world_area.x as i32 + TILE_SIZE.0 as i32 * draw_pos.0;
+            let ry: i32 = world_area.y as i32 + TILE_SIZE.1 as i32 * draw_pos.1;
+            Some(Rect::new(rx as u16, ry as u16, TILE_SIZE.0, TILE_SIZE.1))
+        } else {
+            // tile outside visible area
+            None
+        };
+    };
 
+    // iterate over visible area
+    // draw solid background if outside world
     for y in 0..box_h {
         for x in 0..box_w {
+            // inverse of draw_pos higher up
+            let world_pos = (
+                x as i32 - (box_w / 2) as i32 + camera.0,
+                y as i32 - (box_h / 2) as i32 + camera.1,
+            );
+            
+            if
+                0 <= world_pos.0 && world_pos.0 < WIDTH as i32 &&
+                0 <= world_pos.1 && world_pos.1 < HEIGHT as i32
+            {
+                // if inside world: skip
+                continue;
+            }
+            
             // draw a background in the "World" area
             // this is so the player can tell the difference between buildable area and surrounding borders
-            let rect = Rect::new(world_area.x + TILE_SIZE.0 * x, world_area.y + TILE_SIZE.1 * y, TILE_SIZE.0, TILE_SIZE.1);
-            let square = Paragraph::new(".").gray();
-            // frame.render_widget(square, rect);
+            let rect = Rect::new(
+                world_area.x + TILE_SIZE.0 * x,
+                world_area.y + TILE_SIZE.1 * y,
+                TILE_SIZE.0,
+                TILE_SIZE.1,
+            );
+            
+            let border_tile = "...\n...";
+            let square = Paragraph::new(border_tile).gray();
+            frame.render_widget(square, rect);
         }
     }
 
     // aquire lock until it falls out of scope
-    let world_array = &world_array.lock().unwrap();
+    // let world_array = &world_array.lock().unwrap();
+    
+    // a set seed gives us the same values in the world every time
+    let mut rng = ChaCha8Rng::seed_from_u64(5);
 
+    // draw background
+    // we do this separately so objects are correctly layered on top of the background
+    for y in 0..HEIGHT {
+        for x in 0..WIDTH {
+            // needs to run on every iteration
+            // skipping an iteration would mess up the order
+            let tile_rand: u16 = rng.random();
+            
+            let mut rect_at_pos = match get_rect_from_world_xy(x as i32, y as i32) {
+                None => continue,
+                Some(rect) => rect
+            };
+            
+            let random_tiles = [".", " .", "   .", "\n.", "\n .", "\n  ."];
+            
+            // 1/16 chance
+            if tile_rand < 4004 {
+                let square = Paragraph::new(random_tiles[(tile_rand % 6) as usize]).gray();
+                frame.render_widget(square, rect_at_pos);
+            }
+        }
+    }
+
+    // draw world
     for y in 0..HEIGHT {
         for x in 0..WIDTH {
             let tile = &world_array[y][x];
-            let old_tile_n = &old_world_array[y-1][x];
-            let old_tile_s = &old_world_array[y+1][x];
-            let old_tile_w = &old_world_array[y][x-1];
-            let old_tile_e = &old_world_array[y][x+1];
             
-            let y: i32 = y.try_into().unwrap();
-            let x: i32 = x.try_into().unwrap();
+            let mut animation_dx = 0;
+            let mut animation_dy = 0;
+            
+            if y > 0        && is_same_tile(&old_world_array[y-1][x], tile) {animation_dy = -1}
+            if y+1 < HEIGHT && is_same_tile(&old_world_array[y+1][x], tile) {animation_dy = 1}
+            if x > 0        && is_same_tile(&old_world_array[y][x-1], tile) {animation_dx = -1}
+            if x+1 < WIDTH  && is_same_tile(&old_world_array[y][x+1], tile) {animation_dx = 1}
+            
+            // divide by 2 to get center of screen
             let draw_pos = (
-                x + (box_w / TILE_SIZE.0) as i32 - camera.0,
-                y + (box_h / TILE_SIZE.1) as i32 - camera.1,
+                x as i32 + (box_w / 2) as i32 - camera.0,
+                y as i32 + (box_h / 2) as i32 - camera.1,
             );
             let mut rect_at_pos = if
                 0 <= draw_pos.0 && draw_pos.0 < box_w.into() &&
                 0 <= draw_pos.1 && draw_pos.1 < box_h.into()
             {
-                // tile in visible grid
-                let rx = world_area.x + TILE_SIZE.0*(draw_pos.0 as u16);
-                let ry = world_area.y + TILE_SIZE.1*(draw_pos.1 as u16);
-                Rect::new(rx, ry, TILE_SIZE.0, TILE_SIZE.1)
+                // tile in visible area
+                let rx: i32 = world_area.x as i32 + TILE_SIZE.0 as i32 * draw_pos.0 + animation_dx;
+                let ry: i32 = world_area.y as i32 + TILE_SIZE.1 as i32 * draw_pos.1 + animation_dy;
+                Rect::new(rx as u16, ry as u16, TILE_SIZE.0, TILE_SIZE.1)
             } else {
+                // tile outside visible area
                 continue;
             };
             
-            if is_same_tile(old_tile_n, tile) {rect_at_pos.y -= 1}
-            if is_same_tile(old_tile_s, tile) {rect_at_pos.y += 1}
-            if is_same_tile(old_tile_w, tile) {rect_at_pos.x -= 1}
-            if is_same_tile(old_tile_e, tile) {rect_at_pos.x += 1}
+            let mut rect_at_pos = match get_rect_from_world_xy(x as i32, y as i32) {
+                None => continue,
+                Some(rect) => rect
+            };
+            
+            rect_at_pos.x = (rect_at_pos.x as i32 + animation_dx) as u16;
+            rect_at_pos.y = (rect_at_pos.y as i32 + animation_dy) as u16;
+            
             
             match tile {
-                Tile::Empty => {
-                    // overwrite background
-                    // let square = Paragraph::new("  \n  ");
-                    // frame.render_widget(square, rect_at_pos);
-                }
+                Tile::Empty => {}
                 Tile::Worker(_aid) => {
                     let square = Paragraph::new("╭—╮\n╰—╯").blue();
                     frame.render_widget(square, rect_at_pos);

--- a/src/player_manager.rs
+++ b/src/player_manager.rs
@@ -14,7 +14,8 @@ use ratatui::style::Stylize;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
 // Width and height of a tile on the screen in characters
-const TILE_SIZE: usize = 2;
+// Needs to be u16 for ratatui
+const TILE_SIZE: (u16, u16) = (2, 3);
 
 #[derive(Copy, Clone)]
 struct Camera(i32, i32);
@@ -61,6 +62,11 @@ pub fn render_loop(
             (HEIGHT / 2).try_into().unwrap(),
         );
 
+        
+        let mut world_array: WorldGrid =
+                std::array::from_fn(|_| std::array::from_fn(|_| Tile::Empty));
+        let mut old_world_array = world_array.clone();
+        
         loop {
             //read all messages in mailbox
             while let Ok(msg) = mailbox.try_recv() {
@@ -70,7 +76,7 @@ pub fn render_loop(
                 }
             }
 
-            terminal.draw(|frame| render(frame, &world_array, camera))?;
+            terminal.draw(|frame| render(frame, &old_world_array, &world_array, camera))?;
 
             if poll(Duration::from_millis(30))? {
                 match read()? {
@@ -79,18 +85,10 @@ pub fn render_loop(
                             KeyCode::Char('q') => {
                                 break Ok(());
                             }
-                            KeyCode::Char('w') => {
-                                camera.change(0, -MOVE_CAMERA);
-                            }
-                            KeyCode::Char('s') => {
-                                camera.change(0, MOVE_CAMERA);
-                            }
-                            KeyCode::Char('a') => {
-                                camera.change(-MOVE_CAMERA, 0);
-                            }
-                            KeyCode::Char('d') => {
-                                camera.change(MOVE_CAMERA, 0);
-                            }
+                            KeyCode::Char('w') => {camera.change(0, -MOVE_CAMERA);}
+                            KeyCode::Char('s') => {camera.change(0,  MOVE_CAMERA);}
+                            KeyCode::Char('a') => {camera.change(-MOVE_CAMERA, 0);}
+                            KeyCode::Char('d') => {camera.change( MOVE_CAMERA, 0);}
                             _ => {}
                         }
                     }
@@ -101,24 +99,48 @@ pub fn render_loop(
     })
 }
 
-fn render(frame: &mut Frame, world_array: &WorldGrid, camera: Camera) {
-    let world_area = frame.area().inner(Margin::new(4, 4));
+fn is_same_tile(old_tile: &Tile, new_tile: &Tile) -> bool {
+    match old_tile {
+        Tile::Empty => {
+            false
+        }
+        Tile::Worker(aid) => {
+            match new_tile {
+                Tile::Worker(aid_new) => {
+                    return aid == aid_new;
+                }
+                _ => false
+            }
+        }
+        Tile::Building(aid) => {
+            match new_tile {
+                Tile::Building(aid_new) => {
+                    return aid == aid_new;
+                }
+                _ => false
+            }
+        }
+    }
+}
 
+fn render(frame: &mut Frame, old_world_array: &WorldGrid, world_array: &WorldGrid, camera: Camera) {
+    let world_area = frame.area().inner(Margin::new(4, 4));
+    
     frame.render_widget(
         Block::new().borders(Borders::ALL).title("World"),
         world_area.outer(Margin::new(1, 1)),
     );
 
-    let box_w = world_area.width / 2;
-    let box_h = world_area.height / 2;
+    let box_w = world_area.width / TILE_SIZE.0;
+    let box_h = world_area.height / TILE_SIZE.1;
 
     for y in 0..box_h {
         for x in 0..box_w {
             // draw a background in the "World" area
             // this is so the player can tell the difference between buildable area and surrounding borders
-            let rect = Rect::new(world_area.x + 2 * x, world_area.y + 2 * y, 2, 2);
+            let rect = Rect::new(world_area.x + TILE_SIZE.0 * x, world_area.y + TILE_SIZE.1 * y, TILE_SIZE.0, TILE_SIZE.1);
             let square = Paragraph::new(".").gray();
-            frame.render_widget(square, rect);
+            // frame.render_widget(square, rect);
         }
     }
 
@@ -128,41 +150,46 @@ fn render(frame: &mut Frame, world_array: &WorldGrid, camera: Camera) {
     for y in 0..HEIGHT {
         for x in 0..WIDTH {
             let tile = &world_array[y][x];
-
+            let old_tile_n = &old_world_array[y-1][x];
+            let old_tile_s = &old_world_array[y+1][x];
+            let old_tile_w = &old_world_array[y][x-1];
+            let old_tile_e = &old_world_array[y][x+1];
+            
             let y: i32 = y.try_into().unwrap();
             let x: i32 = x.try_into().unwrap();
             let draw_pos = (
-                x + (box_w / 2) as i32 - camera.0,
-                y + (box_h / 2) as i32 - camera.1,
+                x + (box_w / TILE_SIZE.0) as i32 - camera.0,
+                y + (box_h / TILE_SIZE.1) as i32 - camera.1,
             );
-            let rect_at_pos = if 0 <= draw_pos.0
-                && draw_pos.0 < box_w.into()
-                && 0 <= draw_pos.1
-                && draw_pos.1 < box_h.into()
+            let mut rect_at_pos = if
+                0 <= draw_pos.0 && draw_pos.0 < box_w.into() &&
+                0 <= draw_pos.1 && draw_pos.1 < box_h.into()
             {
                 // tile in visible grid
-                Rect::new(
-                    world_area.x + (2 * draw_pos.0 as u16),
-                    world_area.y + (2 * draw_pos.1 as u16),
-                    2,
-                    2,
-                )
+                let rx = world_area.x + TILE_SIZE.0*(draw_pos.0 as u16);
+                let ry = world_area.y + TILE_SIZE.1*(draw_pos.1 as u16);
+                Rect::new(rx, ry, TILE_SIZE.0, TILE_SIZE.1)
             } else {
                 continue;
             };
-
+            
+            if is_same_tile(old_tile_n, tile) {rect_at_pos.y -= 1}
+            if is_same_tile(old_tile_s, tile) {rect_at_pos.y += 1}
+            if is_same_tile(old_tile_w, tile) {rect_at_pos.x -= 1}
+            if is_same_tile(old_tile_e, tile) {rect_at_pos.x += 1}
+            
             match tile {
                 Tile::Empty => {
                     // overwrite background
-                    let square = Paragraph::new("  \n  ");
-                    frame.render_widget(square, rect_at_pos);
+                    // let square = Paragraph::new("  \n  ");
+                    // frame.render_widget(square, rect_at_pos);
                 }
                 Tile::Worker(_aid) => {
-                    let square = Paragraph::new("╭╮\n╰╯").blue();
+                    let square = Paragraph::new("╭—╮\n╰—╯").blue();
                     frame.render_widget(square, rect_at_pos);
                 }
                 Tile::Building(_aid) => {
-                    let square = Paragraph::new("╔╗\n╚╝").red();
+                    let square = Paragraph::new("╔═╗\n╚═╝").red();
                     frame.render_widget(square, rect_at_pos);
                 }
             }

--- a/src/player_manager.rs
+++ b/src/player_manager.rs
@@ -231,33 +231,15 @@ fn render(frame: &mut Frame, old_world_array: &RawWorldArray, world_array: &RawW
             let mut animation_dx = 0;
             let mut animation_dy = 0;
             
-            if y > 0        && is_same_tile(&old_world_array[y-1][x], tile) {animation_dy = -1}
-            if y+1 < HEIGHT && is_same_tile(&old_world_array[y+1][x], tile) {animation_dy = 1}
-            if x > 0        && is_same_tile(&old_world_array[y][x-1], tile) {animation_dx = -1}
-            if x+1 < WIDTH  && is_same_tile(&old_world_array[y][x+1], tile) {animation_dx = 1}
-            
-            // divide by 2 to get center of screen
-            let draw_pos = (
-                x as i32 + (box_w / 2) as i32 - camera.0,
-                y as i32 + (box_h / 2) as i32 - camera.1,
-            );
-            let mut rect_at_pos = if
-                0 <= draw_pos.0 && draw_pos.0 < box_w.into() &&
-                0 <= draw_pos.1 && draw_pos.1 < box_h.into()
-            {
-                // tile in visible area
-                let rx: i32 = world_area.x as i32 + TILE_SIZE.0 as i32 * draw_pos.0 + animation_dx;
-                let ry: i32 = world_area.y as i32 + TILE_SIZE.1 as i32 * draw_pos.1 + animation_dy;
-                Rect::new(rx as u16, ry as u16, TILE_SIZE.0, TILE_SIZE.1)
-            } else {
-                // tile outside visible area
-                continue;
-            };
-            
             let mut rect_at_pos = match get_rect_from_world_xy(x as i32, y as i32) {
                 None => continue,
                 Some(rect) => rect
             };
+            
+            if y > 0        && is_same_tile(&old_world_array[y-1][x], tile) {animation_dy = -1}
+            if y+1 < HEIGHT && is_same_tile(&old_world_array[y+1][x], tile) {animation_dy = 1}
+            if x > 0        && is_same_tile(&old_world_array[y][x-1], tile) {animation_dx = -1}
+            if x+1 < WIDTH  && is_same_tile(&old_world_array[y][x+1], tile) {animation_dx = 1}
             
             rect_at_pos.x = (rect_at_pos.x as i32 + animation_dx) as u16;
             rect_at_pos.y = (rect_at_pos.y as i32 + animation_dy) as u16;

--- a/src/world_manager.rs
+++ b/src/world_manager.rs
@@ -34,7 +34,7 @@ pub enum Tile {
 }
 
 type WorldLookup = HashMap<AID<EntityMessage>, Pos>;
-type RawWorldArray = Vec<Vec<Tile>>;
+pub type RawWorldArray = Vec<Vec<Tile>>;
 pub type WorldGrid = Arc<Mutex<RawWorldArray>>;
 
 pub fn init_world_grid() -> WorldGrid {


### PR DESCRIPTION
I made a bunch of changes to the rendering:

Tiles are now 3x2. This means that objects are square.
The world covers the entire screen.

Workers are animated when they move. This requires two copies of the world state to compare between. I allocated them on the stack, but testing with a world of size 300x200 did not make it crash with a stack overflow like before. Maybe it's just the message passing that can't be too big? Either way, it works fine now.

Delay between frames is 50 ms. Animations look better with 50 ms than with 30 ms.

There is a proper border around the world. There is also some dots in the background, so you can see where you're going when moving around the camera. Finding the corner in huge worlds is easy now. (The dots require the rand library.)