### PR TITLE
Render performance

### DIFF
--- a/src/player_manager.rs
+++ b/src/player_manager.rs
@@ -1,7 +1,9 @@
 use rand::{RngExt, SeedableRng, rngs::ChaCha8Rng};
 use std::sync::mpsc::Receiver;
 use std::time::Duration;
+use std::time::Instant;
 use std::cmp::Ordering;
+use std::cmp;
 
 use crate::{
     aid::AID,
@@ -84,12 +86,19 @@ pub fn render_loop(
                 }
             }
 
+            let time_0 = Instant::now();
             let new_world = get_copy_of_world(&world_array);
-            terminal.draw(|frame| render(frame, &old_world, &new_world, camera))?;
+            let time_1 = Instant::now();
+            terminal.draw(|frame| render(frame, &old_world, &new_world, camera, (time_0, time_1)))?;
             old_world = new_world;
+            
+            // reduce wait time by how much time we spent rendering
+            // I can't tell if this makes any difference, or if it doesn't work with poll()
+            let time_to_wait = 50;
+            let time_to_wait = cmp::max(0, time_to_wait - time_0.elapsed().as_millis() as i64) as u64;
 
             // 50 ms looks better with animations
-            if poll(Duration::from_millis(50))? {
+            if poll(Duration::from_millis(time_to_wait))? {
                 match read()? {
                     Event::Key(key_event) if key_event.kind == KeyEventKind::Press => {
                         match key_event.code {
@@ -141,6 +150,7 @@ fn render(
     old_world_array: &RawWorldArray,
     world_array: &RawWorldArray,
     camera: Camera,
+    (time_0, time_1): (Instant, Instant),
 ) {
     let world_area = frame.area();
 
@@ -307,4 +317,26 @@ fn render(
             }
         }
     }
+    
+    // return; // don't draw fps
+    let time_2 = Instant::now();
+    render_fps(
+        frame,
+        time_1.duration_since(time_0),
+        time_2.duration_since(time_1),
+    );
+}
+
+fn render_fps(frame: &mut Frame, dur_copy: Duration, dur_render: Duration) {
+    let width = frame.area().width;
+    
+    let text = format!("{} ms", dur_copy.as_millis());
+    let len = text.len() as u16;
+    let rect = Rect::new(width - len, 0, len, 1);
+    frame.render_widget(Paragraph::new(text), rect);
+    
+    let text = format!("{} ms", dur_render.as_millis());
+    let len = text.len() as u16;
+    let rect = Rect::new(width - len, 1, len, 1);
+    frame.render_widget(Paragraph::new(text), rect);
 }

--- a/src/player_manager.rs
+++ b/src/player_manager.rs
@@ -1,6 +1,7 @@
 use rand::{RngExt, SeedableRng, rngs::ChaCha8Rng};
 use std::sync::mpsc::Receiver;
 use std::time::Duration;
+use std::cmp::Ordering;
 
 use crate::{
     aid::AID,
@@ -145,6 +146,17 @@ fn render(
 
     let box_w = world_area.width / TILE_SIZE.0;
     let box_h = world_area.height / TILE_SIZE.1;
+    
+    let is_row_in_world = |y: i32| {
+        let draw_y = y + (box_h / 2) as i32 - camera.1;
+        if draw_y < 0 {
+            return Ordering::Less;
+        }
+        if draw_y >= box_h.into() {
+            return Ordering::Greater;
+        }
+        return Ordering::Equal;
+    };
 
     // this is repeated several times, so it's a closure here
     let get_rect_from_world_xy = |x: i32, y: i32| {
@@ -206,15 +218,27 @@ fn render(
     // let world_array = &world_array.lock().unwrap();
 
     // a set seed gives us the same values in the world every time
+    // this rng is used to set the seed for every row
     let mut rng = ChaCha8Rng::seed_from_u64(5);
 
     // draw background
     // we do this separately so objects are correctly layered on top of the background
     for y in 0..HEIGHT {
+        // this rng applies to every row
+        // needs to run on every iteration
+        // skipping an iteration would mess up the order
+        let mut rng_row = ChaCha8Rng::seed_from_u64(rng.random());
+        
+        match is_row_in_world(y as i32) {
+            Ordering::Less => continue,
+            Ordering::Greater => break,
+            _ => (),
+        }
+        
         for x in 0..WIDTH {
             // needs to run on every iteration
             // skipping an iteration would mess up the order
-            let tile_rand: u16 = rng.random();
+            let tile_rand: u16 = rng_row.random();
 
             let mut rect_at_pos = match get_rect_from_world_xy(x as i32, y as i32) {
                 None => continue,
@@ -233,6 +257,12 @@ fn render(
 
     // draw world
     for y in 0..HEIGHT {
+        match is_row_in_world(y as i32) {
+            Ordering::Less => continue,
+            Ordering::Greater => break,
+            _ => (),
+        }
+        
         for x in 0..WIDTH {
             let tile = &world_array[y][x];
 

--- a/src/player_manager.rs
+++ b/src/player_manager.rs
@@ -330,11 +330,13 @@ fn render(
 fn render_fps(frame: &mut Frame, dur_copy: Duration, dur_render: Duration) {
     let width = frame.area().width;
     
+    // time to run get_copy_of_world() 
     let text = format!("{} ms", dur_copy.as_millis());
     let len = text.len() as u16;
     let rect = Rect::new(width - len, 0, len, 1);
     frame.render_widget(Paragraph::new(text), rect);
     
+    // time to run render()
     let text = format!("{} ms", dur_render.as_millis());
     let len = text.len() as u16;
     let rect = Rect::new(width - len, 1, len, 1);

--- a/src/world_manager.rs
+++ b/src/world_manager.rs
@@ -9,8 +9,8 @@ use crate::{
     messages::{EntityMessage, PlayerManagerMessage},
 };
 
-pub const WIDTH: usize = 32;
-pub const HEIGHT: usize = 16;
+pub const WIDTH: usize = 320;
+pub const HEIGHT: usize = 160;
 
 pub type Pos = (usize, usize);
 


### PR DESCRIPTION
Förut rendrade vi hela världen. För en liten world så går det bra, men för stora så blir det väldigt segt. Jag har gjort så den hoppar över rader som inte visas. Det minskar tiden från O(width*height) till O(width) - inte optimalt, men mer än tillräckligt.

Jag har också lagt till en fps-mätare för att hjälpa mig mäta konkreta siffror. Här är resultaten av tester som jag gjort.
Jag har mätt två tider. Den första är tiden för att göra en kopia av världen. Den andra är tiden för att rendera.

world = 3200 x 1600
Innan: 160 ms copy / 850 ms render
Efter: 160 ms copy / 14 ms render

world = 320 x 160
Innan: 4 ms copy / 25 ms render
Efter: 4 ms copy / 5 ms render