### PR TITLE
Pause the game

### DIFF
--- a/src/building.rs
+++ b/src/building.rs
@@ -11,6 +11,7 @@ use std::{
     sync::{Arc, mpsc::Receiver},
     thread,
     time::Duration,
+    vec,
 };
 
 const MACHINE_TICK_SPEED: Duration = Duration::from_millis(100);
@@ -81,8 +82,25 @@ impl Building {
         let mut active_recipe: Option<RecipeAsset> = None;
         let mut current_process: Option<Duration> = None;
         let mut waiting = false;
+        let mut paused = false;
+        let mut pause_messages: Vec<EntityMessage> = vec![];
         'outer: loop {
             //read all messages in mailbox
+            while paused {
+                if let Ok(msg) = mailbox.recv() {
+                    if let EntityMessage::Unpause = msg {
+                        paused = false;
+                        //send back all messages received while paused, could also send back 
+                        //directly but then it would constantly read messages and never sleep
+                        while let Some(pause_message) = pause_messages.pop() {
+                            _ = self.self_aid.send(pause_message);
+                        }
+                    } else {
+                        pause_messages.push(msg);
+                    }
+                }
+                continue;
+            }
             while let Ok(msg) = mailbox.try_recv() {
                 match msg {
                     EntityMessage::KillYourself => {
@@ -148,7 +166,14 @@ impl Building {
                         )));
                     }
 
-                    EntityMessage::GetInventoryResponse(_) | EntityMessage::MoveResponse(_) => {} // not supposed to happen
+                    EntityMessage::Pause => {
+                        paused = true;
+                        continue 'outer;
+                    }
+
+                    EntityMessage::GetInventoryResponse(_)
+                    | EntityMessage::MoveResponse(_)
+                    | EntityMessage::Unpause => {} // not supposed to happen
                 }
             }
 

--- a/src/building.rs
+++ b/src/building.rs
@@ -88,15 +88,23 @@ impl Building {
             //read all messages in mailbox
             while paused {
                 if let Ok(msg) = mailbox.recv() {
-                    if let EntityMessage::Unpause = msg {
-                        paused = false;
-                        //send back all messages received while paused, could also send back 
-                        //directly but then it would constantly read messages and never sleep
-                        while let Some(pause_message) = pause_messages.pop() {
-                            _ = self.self_aid.send(pause_message);
+                    match msg {
+                        EntityMessage::Unpause => {
+                            paused = false;
+                            //send back all messages received while paused, could also send back 
+                            //directly but then it would constantly read messages and never sleep
+                            while let Some(pause_message) = pause_messages.pop() {
+                                _ = self.self_aid.send(pause_message);
+                            }
                         }
-                    } else {
-                        pause_messages.push(msg);
+                        
+                        EntityMessage::KillYourself => {
+                            break 'outer;
+                        }
+
+                        _ => {
+                            pause_messages.push(msg);
+                        }
                     }
                 }
                 continue;

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -54,7 +54,13 @@ pub enum EntityMessage {
     FetchInventoryStatus(AID<PlayerManagerMessage>),
 
     // sent by player manager spontaneously
+    
     FetchCurrentTask(AID<PlayerManagerMessage>),
+    // sent by world manager spontaneously
+    Pause,
+    
+    // sent by world manager spontaneously
+    Unpause,
 }
 
 #[derive(Clone)]

--- a/src/player_manager.rs
+++ b/src/player_manager.rs
@@ -49,6 +49,12 @@ struct Input {
     key: Option<KeyCode>,
 }
 
+enum InputResult {
+    Pause,
+    Quit,
+    Continue,
+}
+
 #[derive(Copy, Clone)]
 struct Camera(i32, i32);
 
@@ -171,15 +177,36 @@ fn render_loop(
         // For Status information
         let mut inventory_string: Option<String> = None;
         let mut task: Option<Task> = None;
+        
+        let mut paused = false;
+
 
         loop {
             if let Some(true) = check_mailbox(&mailbox, &mut inventory_string, &mut task) {
                 break Ok(());
             }
 
-            if let Some(true) = get_inputs(&mut camera, &mut selected_aid, &old_world, time_to_wait)
+            if let Some(val) = get_inputs(&mut camera, &mut selected_aid, &old_world, time_to_wait)
             {
-                break Ok(());
+                match val {
+
+                    InputResult::Continue => {}
+
+                    InputResult::Quit => {
+                        break Ok(());
+                    }
+
+                    InputResult::Pause => {
+                        if paused {
+                            //unpause
+                            _ = world.send(WorldManagerMessage::Unpause);
+                        } else {
+                            //pause
+                            _ = world.send(WorldManagerMessage::Pause);
+                        }
+                        paused = !paused;
+                    }
+                }
             }
 
             // terminal.draw(|frame| render(frame, world_array, camera, input))?;
@@ -242,7 +269,7 @@ fn get_inputs(
     selected_aid: &mut Option<AID<EntityMessage>>,
     old_world: &RawWorldArray,
     time_to_wait: u64,
-) -> Option<bool> {
+) -> Option<InputResult> {
     let mut key_event: Option<KeyEvent> = None;
     let mut mouse_event: Option<MouseEvent> = None;
 
@@ -253,7 +280,10 @@ fn get_inputs(
                 // Det här måste ske utanför input handler eftersom
                 // det ska stänga av loopen
                 if event.code == KeyCode::Char('q') {
-                    return Some(true); // Break
+                    return Some(InputResult::Quit); // Break
+                }
+                if event.code == KeyCode::Char('p') {
+                    return Some(InputResult::Pause);
                 }
                 key_event = Some(event);
             }
@@ -273,7 +303,7 @@ fn get_inputs(
     parse_input_keyboard(&mut input, &key_event, camera, selected_aid, &old_world);
     parse_input_mouse(&mut input, &mouse_event);
 
-    return Some(false);
+    return Some(InputResult::Continue);
 }
 
 fn parse_input_keyboard(

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -391,15 +391,23 @@ impl Worker {
         'outer: loop {
             while self.paused {
                 if let Ok(msg) = mailbox.recv() {
-                    if let EntityMessage::Unpause = msg {
-                        self.paused = false;
-                        //send back all messages received while paused, could also send back 
-                        //directly but then it would constantly read messages and never sleep
-                        while let Some(pause_msg) = pause_messages.pop() {
-                            _ = self.self_aid.send(pause_msg);
+                    match msg {
+                        EntityMessage::Unpause => {
+                            self.paused = false;
+                            //send back all messages received while paused, could also send back 
+                            //directly but then it would constantly read messages and never sleep
+                            while let Some(pause_message) = pause_messages.pop() {
+                                _ = self.self_aid.send(pause_message);
+                            }
                         }
-                    } else {
-                        pause_messages.push(msg);
+
+                        EntityMessage::KillYourself => {
+                            break 'outer;
+                        }
+
+                        _ => {
+                            pause_messages.push(msg);
+                        }
                     }
                 }
             }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -210,6 +210,7 @@ impl WorkerCore {
 pub struct Worker {
     core: WorkerCore,
     alive: bool,
+    paused: bool,
     waiting: bool,
     pending_inventory_task: Option<(bool, ItemId)>,
     world_aid: AID<WorldManagerMessage>,
@@ -260,6 +261,7 @@ impl Worker {
         Worker {
             core: WorkerCore::new(start_pos),
             alive: true,
+            paused: false,
             waiting: false,
             pending_inventory_task: None,
             world_aid: world,
@@ -375,15 +377,43 @@ impl Worker {
                     self.core.current_task.clone(),
                 )));
             }
+
+            EntityMessage::Pause => {
+                self.paused = true;
+            }
+            
+            EntityMessage::Unpause => {
+                self.paused = false;
+            }
         }
     }
 
     fn run(&mut self, mailbox: &Receiver<EntityMessage>) {
+        let mut pause_messages: Vec<EntityMessage> = vec![];
         'outer: loop {
+            while self.paused {
+                if let Ok(msg) = mailbox.recv() {
+                    if let EntityMessage::Unpause = msg {
+                        self.paused = false;
+                        //send back all messages received while paused, could also send back 
+                        //directly but then it would constantly read messages and never sleep
+                        while let Some(pause_msg) = pause_messages.pop() {
+                            _ = self.self_aid.send(pause_msg);
+                        }
+                    } else {
+                        pause_messages.push(msg);
+                    }
+                }
+            }
+
             while self.waiting {
                 if let Ok(msg) = mailbox.recv() {
                     self.msg_handler(msg);
-
+                    
+                    if self.paused {
+                        continue 'outer;
+                    }
+                    
                     if !self.alive {
                         break 'outer;
                     }
@@ -391,6 +421,10 @@ impl Worker {
             }
             while let Ok(msg) = mailbox.try_recv() {
                 self.msg_handler(msg);
+
+                if self.paused {
+                    continue 'outer;
+                }
 
                 if !self.alive {
                     break 'outer;

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -382,9 +382,7 @@ impl Worker {
                 self.paused = true;
             }
             
-            EntityMessage::Unpause => {
-                self.paused = false;
-            }
+            EntityMessage::Unpause => {} // not supposed to happen
         }
     }
 

--- a/src/world_manager.rs
+++ b/src/world_manager.rs
@@ -27,6 +27,8 @@ pub enum WorldManagerMessage {
     SpawnWorker(Pos, WorkerId),
     SpawnBuilding(Pos, BuildingId, bool),
     KillEntity(AID<EntityMessage>),
+    Pause,
+    Unpause
 }
 
 #[derive(Clone)]
@@ -135,6 +137,17 @@ fn main(
                     *get_tile(grid, pos).unwrap() = Tile::Empty;
 
                     let _ = aid.send(EntityMessage::KillYourself);
+                }
+            }
+            WorldManagerMessage::Pause => {
+                for (entity, _) in &entity_lookup {
+                    _ = entity.send(EntityMessage::Pause);
+                }
+            }
+
+            WorldManagerMessage::Unpause => {
+                for (entity, _) in &entity_lookup {
+                    _ = entity.send(EntityMessage::Unpause);
                 }
             }
         }

--- a/src/zombie.rs
+++ b/src/zombie.rs
@@ -20,7 +20,9 @@ pub fn entity_zombie(mailbox: impl IntoIterator<Item = EntityMessage>) {
             EntityMessage::ItemTransferResponse(_) => {}
             EntityMessage::MoveResponse(_) => {}
             EntityMessage::TaskResponse(_) => {}
-
+            EntityMessage::Pause => {}
+            EntityMessage::Unpause => {}
+            
             EntityMessage::GetInventory(aid) => {
                 let _ = aid.send(EntityMessage::GetInventoryResponse(Err(
                     GetInventoryError::ImDead,
@@ -84,6 +86,8 @@ pub fn world_manager_zombie(mailbox: impl IntoIterator<Item = WorldManagerMessag
             WorldManagerMessage::SpawnWorker(_, _) => {}
             WorldManagerMessage::SpawnBuilding(_, _, _) => {}
             WorldManagerMessage::KillEntity(_) => {}
+            WorldManagerMessage::Pause => {}
+            WorldManagerMessage::Unpause => {}
 
             WorldManagerMessage::Move(_, aid) => {
                 let _ = aid.send(EntityMessage::MoveResponse(Err(MoveError::ImDead)));


### PR DESCRIPTION
This pr makes it possible to pause the game. Pressing p pauses/unpauses the game. 

Pausing is done by sending pause message to all entitites in the world, which then goes into a pause loop until they receive an unpause message. World and task manager are not actively paused. Player manager keeps on rendering as usual, so you will be able to use the camera and select workers (or render some pause menu?).