### PR TITLE
Timer actor

### DIFF
--- a/src/aid.rs
+++ b/src/aid.rs
@@ -16,7 +16,6 @@ pub type AIDHandle = thread::JoinHandle<()>;
 
 impl<T> AID<T> {
     // creates a channel and spawns a thread running f
-    #[cfg(test)]
     pub fn new<F>(f: F) -> Self
     where
         F: FnOnce(AID<T>, mpsc::Receiver<T>),

--- a/src/building.rs
+++ b/src/building.rs
@@ -4,12 +4,12 @@ use crate::{
     inventory::{self, InventoryMessage},
     messages::{EntityMessage, ItemTransferError, PlayerManagerMessage, TaskError},
     task_manager::{Task, TaskManagerMessage},
+    timer::Timer,
     world_manager::WorldManagerMessage,
     zombie,
 };
 use std::{
     sync::{Arc, mpsc::Receiver},
-    thread,
     time::Duration,
     vec,
 };
@@ -21,6 +21,7 @@ pub struct Building {
     task_aid: AID<TaskManagerMessage>,
     self_aid: AID<EntityMessage>,
     inventory: AID<InventoryMessage>,
+    timer: Timer<EntityMessage>,
     assets: Arc<Assets>,
     id: BuildingId,
 }
@@ -62,8 +63,9 @@ impl Building {
         Building {
             world_aid,
             task_aid,
-            self_aid,
             inventory: inventory::init(assets.clone(), inventory_size),
+            timer: Timer::new(self_aid.clone(), EntityMessage::TimerResponse),
+            self_aid,
             assets,
             id,
         }
@@ -81,6 +83,7 @@ impl Building {
         let mut current_task = Task::Idle;
         let mut active_recipe: Option<RecipeAsset> = None;
         let mut current_process: Option<Duration> = None;
+        let mut sleeping = false;
         let mut waiting = false;
         let mut paused = false;
         let mut pause_messages: Vec<EntityMessage> = vec![];
@@ -91,13 +94,13 @@ impl Building {
                     match msg {
                         EntityMessage::Unpause => {
                             paused = false;
-                            //send back all messages received while paused, could also send back 
+                            //send back all messages received while paused, could also send back
                             //directly but then it would constantly read messages and never sleep
                             while let Some(pause_message) = pause_messages.pop() {
                                 _ = self.self_aid.send(pause_message);
                             }
                         }
-                        
+
                         EntityMessage::KillYourself => {
                             break 'outer;
                         }
@@ -109,10 +112,18 @@ impl Building {
                 }
                 continue;
             }
-            while let Ok(msg) = mailbox.try_recv() {
+
+            while let Some(msg) = if sleeping {
+                mailbox.recv().ok()
+            } else {
+                mailbox.try_recv().ok()
+            } {
                 match msg {
                     EntityMessage::KillYourself => {
                         break 'outer;
+                    }
+                    EntityMessage::TimerResponse => {
+                        sleeping = false;
                     }
                     EntityMessage::ItemTransferResponse(res) => match res {
                         Ok(()) => {
@@ -213,7 +224,9 @@ impl Building {
                     current_process = Some(time_left.saturating_sub(MACHINE_TICK_SPEED));
                 }
             }
-            thread::sleep(MACHINE_TICK_SPEED);
+
+            self.timer.start_timer(MACHINE_TICK_SPEED);
+            sleeping = true;
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod inventory;
 mod messages;
 mod player_manager;
 mod task_manager;
+mod timer;
 mod worker;
 mod world_manager;
 mod zombie;

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -34,6 +34,9 @@ pub enum EntityMessage {
     // sent by world manager spontaneously
     KillYourself,
 
+    // sent by timer responding to start_timer
+    TimerResponse,
+
     // sent by worker to building spontaneously
     GetInventory(AID<EntityMessage>),
 
@@ -53,11 +56,11 @@ pub enum EntityMessage {
     FetchInventoryStatus(AID<PlayerManagerMessage>),
 
     // sent by player manager spontaneously
-    
     FetchCurrentTask(AID<PlayerManagerMessage>),
+
     // sent by world manager spontaneously
     Pause,
-    
+
     // sent by world manager spontaneously
     Unpause,
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,0 +1,29 @@
+use std::{marker::PhantomData, thread, time::Duration};
+
+use crate::aid::AID;
+
+pub struct Timer<T> {
+    _phantom: PhantomData<T>,
+    aid: AID<Duration>,
+}
+
+impl<T: Send + 'static + Clone> Timer<T> {
+    pub fn new(owner: AID<T>, message: T) -> Self {
+        return Timer::<T> {
+            _phantom: PhantomData,
+            aid: AID::new(move |aid, mailbox| {
+                drop(aid);
+                // doesn't need a KillYouself or zombie because it only communicates
+                // with its owner and automatically dies once the owner drops the refernce
+                for msg in mailbox {
+                    thread::sleep(msg);
+                    let _ = owner.send(message.clone());
+                }
+            }),
+        };
+    }
+
+    pub fn start_timer(&self, time: Duration) {
+        let _ = self.aid.send(time);
+    }
+}

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -27,3 +27,36 @@ impl<T: Send + 'static + Clone> Timer<T> {
         let _ = self.aid.send(time);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc::TryRecvError;
+
+    use super::*;
+
+    #[test]
+    fn responds() {
+        let (mock, mailbox) = AID::mock();
+        let timer = Timer::new(mock, "test");
+        timer.start_timer(Duration::ZERO);
+        assert!(matches!(mailbox.recv(), Ok("test")));
+    }
+
+    #[test]
+    fn responds_in_time() {
+        let (mock, mailbox) = AID::mock();
+        let timer = Timer::new(mock, "test");
+        timer.start_timer(Duration::from_millis(500));
+        thread::sleep(Duration::from_millis(600));
+        assert!(matches!(mailbox.try_recv(), Ok("test")));
+    }
+
+    #[test]
+    fn responds_not_too_early() {
+        let (mock, mailbox) = AID::mock();
+        let timer = Timer::new(mock, "test");
+        timer.start_timer(Duration::from_millis(600));
+        thread::sleep(Duration::from_millis(500));
+        assert!(matches!(mailbox.try_recv(), Err(TryRecvError::Empty)));
+    }
+}

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -5,12 +5,12 @@ use crate::messages::{
     EntityMessage, GetInventoryError, ItemTransferError, MoveError, PlayerManagerMessage, TaskError,
 };
 use crate::task_manager::{Task, TaskManagerMessage};
-use crate::world_manager::{Pos, WorldManagerMessage,HEIGHT,WIDTH};
+use crate::timer::Timer;
+use crate::world_manager::{HEIGHT, Pos, WIDTH, WorldManagerMessage};
 use crate::zombie;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::sync::mpsc::Receiver;
-use std::thread;
 use std::time::Duration;
 
 // duration to wait while idling
@@ -80,7 +80,7 @@ impl WorkerCore {
         WorkerCore {
             current_pos: start_pos,
             current_task: Task::Idle,
-            carry_capacity:carry_capacity,
+            carry_capacity: carry_capacity,
             sub_tasks: VecDeque::new(),
             open_neighbors: neighbors(start_pos),
             heuristic: HashMap::new(),
@@ -173,23 +173,20 @@ impl WorkerCore {
                 self.sub_tasks.push_back(SubTask::Move(pos));
                 self.current_task = Task::MoveTo(pos);
             }
-            Task::DeliverItem(item,(from_aid, from), (to_aid, to)) => {
-            let stack = ItemStack::new(item.clone(), self.carry_capacity);
+            Task::DeliverItem(item, (from_aid, from), (to_aid, to)) => {
+                let stack = ItemStack::new(item.clone(), self.carry_capacity);
 
-            self.sub_tasks.push_back(SubTask::Move(from));
+                self.sub_tasks.push_back(SubTask::Move(from));
 
-            self.sub_tasks.push_back(
-                SubTask::TakeItem(from_aid.clone(), stack.clone())
-            );
+                self.sub_tasks
+                    .push_back(SubTask::TakeItem(from_aid.clone(), stack.clone()));
 
-            self.sub_tasks.push_back(SubTask::Move(to));
+                self.sub_tasks.push_back(SubTask::Move(to));
 
-            self.sub_tasks.push_back(
-                SubTask::GiveItem(to_aid.clone(), stack)
-            );
+                self.sub_tasks
+                    .push_back(SubTask::GiveItem(to_aid.clone(), stack));
 
-            self.current_task =
-                Task::DeliverItem(item, (from_aid, from), (to_aid, to));
+                self.current_task = Task::DeliverItem(item, (from_aid, from), (to_aid, to));
             }
             Task::Idle => {
                 self.sub_tasks.clear();
@@ -226,12 +223,14 @@ impl WorkerCore {
 pub struct Worker {
     core: WorkerCore,
     alive: bool,
+    sleeping: bool,
     paused: bool,
     waiting: bool,
     pending_inventory_task: Option<(bool, ItemStack)>,
     world_aid: AID<WorldManagerMessage>,
     task_aid: AID<TaskManagerMessage>,
     inventory: AID<InventoryMessage>,
+    timer: Timer<EntityMessage>,
     self_aid: AID<EntityMessage>,
     assets: Arc<Assets>,
     id: WorkerId,
@@ -246,7 +245,7 @@ impl Worker {
         assets: Arc<Assets>,
         id: WorkerId,
     ) -> AID<EntityMessage> {
-        Worker::new_joinable(world, task, start_pos, carry_capacity,assets, id).0
+        Worker::new_joinable(world, task, start_pos, carry_capacity, assets, id).0
     }
 
     pub fn new_joinable(
@@ -258,7 +257,8 @@ impl Worker {
         id: WorkerId,
     ) -> (AID<EntityMessage>, AIDHandle) {
         AID::new_joinable(move |aid, mailbox| {
-            let mut worker = Worker::create(aid, world, task, start_pos, carry_capacity,assets, id);
+            let mut worker =
+                Worker::create(aid, world, task, start_pos, carry_capacity, assets, id);
             worker.run(&mailbox);
 
             worker.destroy();
@@ -267,25 +267,27 @@ impl Worker {
     }
 
     fn create(
-    self_aid: AID<EntityMessage>,
-    world: AID<WorldManagerMessage>,
-    task: AID<TaskManagerMessage>,
-    start_pos: Pos,
-    carry_capacity: usize,
-    assets: Arc<Assets>,
-    id: WorkerId,
-) -> Self {
+        self_aid: AID<EntityMessage>,
+        world: AID<WorldManagerMessage>,
+        task: AID<TaskManagerMessage>,
+        start_pos: Pos,
+        carry_capacity: usize,
+        assets: Arc<Assets>,
+        id: WorkerId,
+    ) -> Self {
         let inventory_size = assets.workers.get(&id).unwrap().inventory_size;
 
         Worker {
-            core: WorkerCore::new(start_pos,carry_capacity),
+            core: WorkerCore::new(start_pos, carry_capacity),
             alive: true,
+            sleeping: false,
             paused: false,
             waiting: false,
             pending_inventory_task: None,
             world_aid: world,
             task_aid: task,
             inventory: inventory::init(assets.clone(), inventory_size),
+            timer: Timer::new(self_aid.clone(), EntityMessage::TimerResponse),
             self_aid: self_aid,
             assets,
             id,
@@ -315,6 +317,10 @@ impl Worker {
                 self.alive = false;
             }
 
+            EntityMessage::TimerResponse => {
+                self.sleeping = false;
+            }
+
             EntityMessage::TaskResponse(res) => match res {
                 Ok(task) => {
                     self.core.new_task(task);
@@ -332,7 +338,9 @@ impl Worker {
 
                     let speed = self.assets.workers.get(&self.id).unwrap().speed;
                     let time = Duration::from_secs_f32(MOVE_TIME.as_secs_f32() / speed);
-                    thread::sleep(time);
+
+                    self.sleeping = true;
+                    self.timer.start_timer(time);
                 }
                 Err(MoveError::Occupied(pos)) => {
                     // world manager neckade flytten
@@ -367,34 +375,26 @@ impl Worker {
             }
 
             EntityMessage::GetInventoryResponse(res) => match res {
-            Ok(inventory) => {
-                if let Some((send, item_stack)) =
-                    self.pending_inventory_task.clone()
-                {
-                    if send {
-                        let _ = self.inventory.send(
-                            InventoryMessage::GiveTo(
+                Ok(inventory) => {
+                    if let Some((send, item_stack)) = self.pending_inventory_task.clone() {
+                        if send {
+                            let _ = self.inventory.send(InventoryMessage::GiveTo(
                                 self.self_aid.clone(),
                                 inventory,
                                 vec![item_stack],
-                            )
-                        );
-                    } else {
-                        let _ = self.inventory.send(
-                            InventoryMessage::TakeFrom(
+                            ));
+                        } else {
+                            let _ = self.inventory.send(InventoryMessage::TakeFrom(
                                 self.self_aid.clone(),
                                 inventory,
                                 vec![item_stack],
-                            )
-                        );
+                            ));
+                        }
                     }
                 }
-            }
 
-            Err(GetInventoryError::ImWorker | GetInventoryError::ImDead) => {
-                self.invalid_task()
-            }
-        },
+                Err(GetInventoryError::ImWorker | GetInventoryError::ImDead) => self.invalid_task(),
+            },
 
             EntityMessage::FetchInventoryStatus(pm_aid) => {
                 _ = self.inventory.send(InventoryMessage::GiveStatus(pm_aid));
@@ -409,7 +409,7 @@ impl Worker {
             EntityMessage::Pause => {
                 self.paused = true;
             }
-            
+
             EntityMessage::Unpause => {} // not supposed to happen
         }
     }
@@ -422,7 +422,7 @@ impl Worker {
                     match msg {
                         EntityMessage::Unpause => {
                             self.paused = false;
-                            //send back all messages received while paused, could also send back 
+                            //send back all messages received while paused, could also send back
                             //directly but then it would constantly read messages and never sleep
                             while let Some(pause_message) = pause_messages.pop() {
                                 _ = self.self_aid.send(pause_message);
@@ -440,14 +440,14 @@ impl Worker {
                 }
             }
 
-            while self.waiting {
+            while self.waiting || self.sleeping {
                 if let Ok(msg) = mailbox.recv() {
                     self.msg_handler(msg);
-                    
+
                     if self.paused {
                         continue 'outer;
                     }
-                    
+
                     if !self.alive {
                         break 'outer;
                     }
@@ -469,7 +469,8 @@ impl Worker {
             let task = self.core.process_task();
             match task {
                 SubTask::Idle => {
-                    thread::sleep(IDLE_TIME);
+                    self.sleeping = true;
+                    self.timer.start_timer(IDLE_TIME);
                 }
                 SubTask::Move(pos) => {
                     let _ = self
@@ -487,13 +488,15 @@ impl Worker {
                     self.pending_inventory_task = Some((true, item_and_amount));
                     let _ = to.send(EntityMessage::GetInventory(self.self_aid.clone()));
                     self.waiting = true;
-                    thread::sleep(TRANSFER_TIME);
+                    self.sleeping = true;
+                    self.timer.start_timer(TRANSFER_TIME);
                 }
                 SubTask::TakeItem(from, item_and_amount) => {
                     self.pending_inventory_task = Some((false, item_and_amount));
                     let _ = from.send(EntityMessage::GetInventory(self.self_aid.clone()));
                     self.waiting = true;
-                    thread::sleep(TRANSFER_TIME);
+                    self.sleeping = true;
+                    self.timer.start_timer(TRANSFER_TIME);
                 }
             }
         }
@@ -513,7 +516,7 @@ mod tests {
     #[test]
     fn process_task_done() {
         let start_pos = (1, 1);
-        let mut core = WorkerCore::new(start_pos,10);
+        let mut core = WorkerCore::new(start_pos, 10);
 
         let result = core.process_task();
 
@@ -523,7 +526,7 @@ mod tests {
     #[test]
     fn process_task_move() {
         let start_pos = (1, 1);
-        let mut core = WorkerCore::new(start_pos,10);
+        let mut core = WorkerCore::new(start_pos, 10);
 
         let new_pos = (10, 10);
         core.new_task(Task::MoveTo(new_pos));
@@ -541,7 +544,7 @@ mod tests {
     #[test]
     fn process_task_idle() {
         let start_pos = (1, 1);
-        let mut core = WorkerCore::new(start_pos,10);
+        let mut core = WorkerCore::new(start_pos, 10);
 
         // position utanför världen världen är 32,16
         let impossible_pos = (1000, 1000);
@@ -555,7 +558,7 @@ mod tests {
     #[test]
     fn new_task_move_to() {
         let start_pos = (1, 1);
-        let mut core = WorkerCore::new(start_pos,10);
+        let mut core = WorkerCore::new(start_pos, 10);
 
         let new_pos = (10, 10);
         let task = Task::MoveTo(new_pos);
@@ -632,22 +635,18 @@ mod tests {
     fn new_task_idle() {
         let start_pos = (1, 1);
 
-        let mut core = WorkerCore::new(start_pos,10);
+        let mut core = WorkerCore::new(start_pos, 10);
 
         let task = Task::Idle;
         core.new_task(task);
 
-        assert_eq!(core.sub_tasks.len(), 1);
-
-        let subtask = core.sub_tasks.pop_front().unwrap();
-
-        assert!(matches!(subtask, SubTask::Idle));
+        assert!(core.sub_tasks.is_empty());
     }
 
     #[test]
     fn apply_ok() {
         let start_pos = (1, 1);
-        let mut core = WorkerCore::new(start_pos,10);
+        let mut core = WorkerCore::new(start_pos, 10);
 
         let new_pos = (12, 12);
         let task = Task::MoveTo(new_pos);
@@ -660,7 +659,7 @@ mod tests {
     #[test]
     fn apply_err() {
         let start_pos = (1, 1);
-        let mut core = WorkerCore::new(start_pos,10);
+        let mut core = WorkerCore::new(start_pos, 10);
 
         let new_pos = (3, 8);
         let task = Task::MoveTo(new_pos);

--- a/src/zombie.rs
+++ b/src/zombie.rs
@@ -16,13 +16,14 @@ pub fn entity_zombie(mailbox: impl IntoIterator<Item = EntityMessage>) {
             // requires a response. If we forget to add something here, it
             // can cause deadlocks.
             EntityMessage::KillYourself => {}
+            EntityMessage::TimerResponse => {}
             EntityMessage::GetInventoryResponse(_) => {}
             EntityMessage::ItemTransferResponse(_) => {}
             EntityMessage::MoveResponse(_) => {}
             EntityMessage::TaskResponse(_) => {}
             EntityMessage::Pause => {}
             EntityMessage::Unpause => {}
-            
+
             EntityMessage::GetInventory(aid) => {
                 let _ = aid.send(EntityMessage::GetInventoryResponse(Err(
                     GetInventoryError::ImDead,
@@ -150,7 +151,7 @@ mod tests {
         let (mock, mailbox) = AID::mock();
 
         let (worker_aid, worker_handle) =
-            Worker::new_joinable(world, task, (0, 0), 10,assets, WorkerId::from("worker"));
+            Worker::new_joinable(world, task, (0, 0), 10, assets, WorkerId::from("worker"));
 
         let _ = worker_aid.send(EntityMessage::KillYourself);
         thread::sleep(Duration::from_millis(250));


### PR DESCRIPTION
resolves #75 

I came to realize that having inventories as separate actors doesn't help when you still need to ask the building for its inventory. Giving in to the sunk cost fallacy, i decided to add a third actor into the mix whose only job is to sleep and send a message to the entity when a certain time has passed. This basically just means the entity can answer messages while sleeping and comes with the added benefit of the game being quicker to turn off since the synchronization never has to wait for someone sleeping.

Also fixed a failing test introduced in #60 